### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Hey! 

Awesome app, judging by the screenshots, I'm looking forward to the version for Android, looks cool! :champagne: 

>[EditorConfig](http://editorconfig.org/) is a standardized opt-in way to help collaborators auto-set their editor on a per-project basis for various formatting options, e.g. spacing and tabs. Some editors (e.g. WebStorm) honor it out of the box; others (e.g. VSC) require installing a small extension. EditorConfig files also affect how code renders in certain engines, including GitHub's web interface.

