### PR TITLE
Syntax highlighting in PR Diff

### DIFF
--- a/src/components/code-line.component.js
+++ b/src/components/code-line.component.js
@@ -1,12 +1,12 @@
 // @flow
 /* eslint-disable no-nested-ternary */
 
-import React from 'react';
+import React, { Component } from 'react';
 import { View, Text, StyleSheet, Dimensions } from 'react-native';
-
+import SyntaxHighlighter from 'react-native-syntax-highlighter';
+import { getLanguage } from 'lowlight';
+import { github as GithubStyle } from 'react-syntax-highlighter/dist/styles';
 import { colors, normalize } from 'config';
-
-type Props = { newChunk: boolean, change: Object };
 
 const styles = StyleSheet.create({
   container: {
@@ -63,44 +63,78 @@ const styles = StyleSheet.create({
   },
 });
 
-export const CodeLine = ({ newChunk, change }: Props) =>
-  <View style={styles.container}>
-    <View style={styles.wrapper}>
-      <View
-        style={[
-          styles.lineNumbers,
-          newChunk && styles.newChunkLineNumbers,
-          change.type === 'add' && styles.addLineNumbers,
-          change.type === 'del' && styles.delLineNumbers,
-        ]}
-      >
-        <Text style={styles.codeLineNumber}>
-          {change.type === 'del'
-            ? change.ln
-            : change.type === 'normal'
-              ? change.ln1
-              : change.type === 'add' ? '' : '...'}
-        </Text>
-        <Text style={styles.codeLineNumber}>
-          {change.type === 'add'
-            ? change.ln
-            : change.type === 'normal'
-              ? change.ln2
-              : change.type === 'del' ? '' : '...'}
-        </Text>
-      </View>
+export class CodeLine extends Component {
+  props: {
+    newChunk: boolean,
+    change: Object,
+    filename: string
+  };
 
-      <View
-        style={[
-          styles.codeLineContainer,
-          newChunk && styles.newChunkLineContainer,
-          change.type === 'add' && styles.addLine,
-          change.type === 'del' && styles.delLine,
-        ]}
-      >
-        <Text style={[styles.codeLine, newChunk && styles.newChunkLine]}>
-          {change.content}
-        </Text>
+  isKnownType(language) {
+    return language && getLanguage(language) && !this.props.newChunk;
+  }
+
+  render() {
+    const { newChunk, change, filename } = this.props;
+    const language = (filename || []).split('.').pop();
+    // SyntaxHighlighter doesn't allow Stylesheet class style
+    const customStyle = {
+      backgroundColor: 'transparent',
+      padding: 0
+    };
+
+    return (
+      <View style={styles.container}>
+        <View style={styles.wrapper}>
+          <View
+            style={[
+              styles.lineNumbers,
+              newChunk && styles.newChunkLineNumbers,
+              change.type === 'add' && styles.addLineNumbers,
+              change.type === 'del' && styles.delLineNumbers,
+            ]}
+          >
+            <Text style={styles.codeLineNumber}>
+              {change.type === 'del'
+                ? change.ln
+                : change.type === 'normal'
+                    ? change.ln1
+                    : change.type === 'add' ? '' : '...'}
+            </Text>
+            <Text style={styles.codeLineNumber}>
+              {change.type === 'add'
+                ? change.ln
+                : change.type === 'normal'
+                    ? change.ln2
+                    : change.type === 'del' ? '' : '...'}
+            </Text>
+          </View>
+
+          <View
+            style={[
+              styles.codeLineContainer,
+              newChunk && styles.newChunkLineContainer,
+              change.type === 'add' && styles.addLine,
+              change.type === 'del' && styles.delLine,
+            ]}
+          >
+            {(newChunk || !this.isKnownType(language)) &&
+              <Text style={[styles.codeLine, newChunk && styles.newChunkLine]}>
+                {change.content}
+              </Text>
+            }
+
+            {this.isKnownType(language) &&
+              <SyntaxHighlighter
+                language={language}
+                style={GithubStyle}
+                CodeTag={Text}
+                codeTagProps={{style: styles.codeLine}}
+                customStyle={customStyle}>{change.content}</SyntaxHighlighter>
+            }
+          </View>
+        </View>
       </View>
-    </View>
-  </View>;
+    );
+  }
+}

--- a/src/components/code-line.component.js
+++ b/src/components/code-line.component.js
@@ -67,7 +67,7 @@ export class CodeLine extends Component {
   props: {
     newChunk: boolean,
     change: Object,
-    filename: string
+    filename: string,
   };
 
   isKnownType(language) {
@@ -80,7 +80,7 @@ export class CodeLine extends Component {
     // SyntaxHighlighter doesn't allow Stylesheet class style
     const customStyle = {
       backgroundColor: 'transparent',
-      padding: 0
+      padding: 0,
     };
 
     return (
@@ -98,15 +98,15 @@ export class CodeLine extends Component {
               {change.type === 'del'
                 ? change.ln
                 : change.type === 'normal'
-                    ? change.ln1
-                    : change.type === 'add' ? '' : '...'}
+                  ? change.ln1
+                  : change.type === 'add' ? '' : '...'}
             </Text>
             <Text style={styles.codeLineNumber}>
               {change.type === 'add'
                 ? change.ln
                 : change.type === 'normal'
-                    ? change.ln2
-                    : change.type === 'del' ? '' : '...'}
+                  ? change.ln2
+                  : change.type === 'del' ? '' : '...'}
             </Text>
           </View>
 
@@ -121,17 +121,18 @@ export class CodeLine extends Component {
             {(newChunk || !this.isKnownType(language)) &&
               <Text style={[styles.codeLine, newChunk && styles.newChunkLine]}>
                 {change.content}
-              </Text>
-            }
+              </Text>}
 
             {this.isKnownType(language) &&
               <SyntaxHighlighter
                 language={language}
                 style={GithubStyle}
                 CodeTag={Text}
-                codeTagProps={{style: styles.codeLine}}
-                customStyle={customStyle}>{change.content}</SyntaxHighlighter>
-            }
+                codeTagProps={{ style: styles.codeLine }}
+                customStyle={customStyle}
+              >
+                {change.content}
+              </SyntaxHighlighter>}
           </View>
         </View>
       </View>

--- a/src/repository/screens/pull-diff.screen.js
+++ b/src/repository/screens/pull-diff.screen.js
@@ -110,6 +110,7 @@ class PullDiff extends Component {
   };
 
   renderItem = ({ item }) => {
+    const filename = item.deleted ? item.from : item.to;
     const chunks = item.chunks.map((chunk, index) => {
       return (
         <ScrollView
@@ -122,11 +123,14 @@ class PullDiff extends Component {
               key={index}
               newChunk
               change={{ content: chunk.content }}
-            />
+              filename={filename} />
 
-            {chunk.changes.map((change, changesIndex) =>
-              <CodeLine key={changesIndex} change={change} />
-            )}
+            {chunk.changes.map((change, changesIndex) => (
+              <CodeLine
+                key={changesIndex}
+                change={change}
+                filename={filename} />
+            ))}
           </View>
         </ScrollView>
       );


### PR DESCRIPTION
> Will be great to have syntax highlighting on `PullDiffScreen` for pull requests

As @housseindjirdeh said here : https://github.com/gitpoint/git-point/pull/60#issuecomment-315512222 

So this PR is about this integration.  
Screenshots:
![Screenshots...](https://user-images.githubusercontent.com/9287184/28243667-bbd7e954-69a9-11e7-8796-7cb87b820e6c.png)

Because of how each line are generated (separately), there is a "Syntax Highlighter" on each line. I did some performance tests to show you that it's not very slower than before (but, yes it is! Especially in case of a lot of line diff).

| | Before | Now | |
|:-:|:-:|:-:|:-:|
| PR #49 | 2480 ms | 4090 ms | +64% |
| PR #79 | 700 ms | 1010 ms | +27% |

_Tested on my iPhone 6S and a "manual chronometer" (human imprecision)_