### PR TITLE
add fonts config file, for #87

### DIFF
--- a/src/auth/screens/auth-profile.screen.js
+++ b/src/auth/screens/auth-profile.screen.js
@@ -12,7 +12,7 @@ import {
   ParallaxScroll,
   UserListItem,
 } from 'components';
-import { colors } from 'config';
+import { colors, fonts } from 'config';
 import { getUser, getOrgs } from 'auth';
 
 const mapStateToProps = state => ({
@@ -30,11 +30,11 @@ const mapDispatchToProps = dispatch => ({
 const styles = StyleSheet.create({
   listTitle: {
     color: colors.black,
-    fontFamily: 'AvenirNext-Medium',
+    ...fonts.fontPrimary,
   },
   listSubTitle: {
     color: colors.greyDark,
-    fontFamily: 'AvenirNext-Medium',
+    ...fonts.fontPrimary,
   },
 });
 

--- a/src/auth/screens/events.screen.js
+++ b/src/auth/screens/events.screen.js
@@ -6,7 +6,7 @@ import { StyleSheet, Text, FlatList, View } from 'react-native';
 import moment from 'moment';
 
 import { LoadingUserListItem, UserListItem, ViewContainer } from 'components';
-import { colors, normalize } from 'config';
+import { colors, fonts, normalize } from 'config';
 import { emojifyText } from 'utils';
 import { getUserEvents } from '../auth.action';
 
@@ -43,17 +43,17 @@ const styles = StyleSheet.create({
     flex: 1,
     marginLeft: 10,
     color: colors.primaryDark,
-    fontFamily: 'AvenirNext-Regular',
+    ...fonts.fontPrimaryLight,
   },
   linkDescription: {
-    fontFamily: 'AvenirNext-DemiBold',
+    ...fonts.fontPrimarySemiBold,
   },
   linkBranchDescription: {
-    fontFamily: 'Menlo',
+    ...fonts.fontCode,
   },
   deletedLinkBranchDescription: {
     color: colors.greyDarkest,
-    fontFamily: 'Menlo',
+    ...fonts.fontCode,
   },
   date: {
     color: colors.greyDark,
@@ -68,7 +68,7 @@ const styles = StyleSheet.create({
     color: colors.greyDark,
     fontSize: normalize(11),
     marginTop: 1,
-    fontWeight: '600',
+    ...fonts.fontPrimarySemiBold,
   },
   textContainer: {
     flex: 1,
@@ -79,7 +79,7 @@ const styles = StyleSheet.create({
   noneTitle: {
     fontSize: normalize(14),
     textAlign: 'center',
-    fontFamily: 'AvenirNext-Medium',
+    ...fonts.fontPrimary,
   },
 });
 

--- a/src/auth/screens/login.screen.js
+++ b/src/auth/screens/login.screen.js
@@ -14,7 +14,7 @@ import SafariView from 'react-native-safari-view';
 import queryString from 'query-string';
 
 import { ViewContainer, LoadingContainer } from 'components';
-import { normalize } from 'config';
+import { fonts, normalize } from 'config';
 import { CLIENT_ID } from 'api';
 import { auth } from 'auth';
 
@@ -56,7 +56,7 @@ const styles = StyleSheet.create({
     height: 100,
   },
   buttonText: {
-    fontWeight: 'bold',
+    ...fonts.fontPrimaryBold,
     fontSize: normalize(16),
   },
 });

--- a/src/auth/screens/welcome.screen.js
+++ b/src/auth/screens/welcome.screen.js
@@ -5,7 +5,7 @@ import { Button } from 'react-native-elements';
 import { NavigationActions } from 'react-navigation';
 
 import { ViewContainer } from 'components';
-import { colors, normalize } from 'config';
+import { colors, fonts, normalize } from 'config';
 
 const mapStateToProps = state => ({
   isAuthenticated: state.auth.isAuthenticated,
@@ -21,7 +21,7 @@ const styles = StyleSheet.create({
   welcomeMessage: {
     color: colors.primarydark,
     fontSize: normalize(24),
-    fontFamily: 'AvenirNext-Medium',
+    ...fonts.fontPrimary,
   },
   loadingIcon: {
     marginTop: 30,
@@ -32,6 +32,10 @@ const styles = StyleSheet.create({
     borderRadius: 3,
     paddingVertical: 5,
     width: 100,
+  },
+  buttonText: {
+    ...fonts.fontPrimaryBold,
+    fontSize: normalize(16),
   },
 });
 
@@ -69,9 +73,8 @@ class Welcome extends Component {
             <Button
               raised
               title="Enter"
-              fontSize={16}
-              fontWeight="bold"
               buttonStyle={styles.enterButton}
+              textStyle={styles.buttonText}
               color={colors.white}
               onPress={() => this._navigateTo('Main')}
             />}

--- a/src/components/code-line.component.js
+++ b/src/components/code-line.component.js
@@ -6,7 +6,7 @@ import { View, Text, StyleSheet, Dimensions } from 'react-native';
 import SyntaxHighlighter from 'react-native-syntax-highlighter';
 import { getLanguage } from 'lowlight';
 import { github as GithubStyle } from 'react-syntax-highlighter/dist/styles';
-import { colors, normalize } from 'config';
+import { colors, fonts, normalize } from 'config';
 
 const styles = StyleSheet.create({
   container: {
@@ -21,7 +21,7 @@ const styles = StyleSheet.create({
     flex: 0.85,
   },
   codeLine: {
-    fontFamily: 'Menlo',
+    ...fonts.fontCode,
     fontSize: normalize(10),
     paddingHorizontal: 10,
     paddingVertical: 3,
@@ -55,7 +55,7 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
   },
   codeLineNumber: {
-    fontFamily: 'Menlo',
+    ...fonts.fontCode,
     fontSize: normalize(10),
     flex: 1,
     alignItems: 'center',

--- a/src/components/comment-input.component.js
+++ b/src/components/comment-input.component.js
@@ -10,7 +10,7 @@ import {
 } from 'react-native';
 import { Icon } from 'react-native-elements';
 
-import { colors, normalize } from 'config';
+import { colors, fonts, normalize } from 'config';
 
 const styles = StyleSheet.create({
   container: {
@@ -31,7 +31,7 @@ const styles = StyleSheet.create({
     marginLeft: 15,
     marginRight: 5,
     color: colors.black,
-    fontFamily: 'AvenirNext-Regular',
+    ...fonts.fontPrimaryLight,
   },
   postButtonContainer: {
     flex: 0.15,
@@ -41,7 +41,7 @@ const styles = StyleSheet.create({
   postButton: {
     fontSize: normalize(12),
     letterSpacing: 1,
-    fontFamily: 'AvenirNext-DemiBold',
+    ...fonts.fontPrimarySemiBold,
   },
   postButtonDisabled: {
     color: colors.grey,

--- a/src/components/comment-list-item.component.js
+++ b/src/components/comment-list-item.component.js
@@ -6,7 +6,7 @@ import { StyleSheet, View, Text, TouchableOpacity, Image } from 'react-native';
 import HTMLView from 'react-native-htmlview';
 import moment from 'moment';
 
-import { colors, normalize } from 'config';
+import { colors, fonts, normalize } from 'config';
 
 const styles = StyleSheet.create({
   container: {
@@ -37,7 +37,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   linkDescription: {
-    fontFamily: 'AvenirNext-DemiBold',
+    ...fonts.fontPrimarySemiBold,
     color: colors.primaryDark,
   },
   date: {
@@ -53,23 +53,23 @@ const styles = StyleSheet.create({
   },
   commentText: {
     color: colors.primaryDark,
-    fontFamily: 'AvenirNext-Regular',
+    ...fonts.fontPrimaryLight,
   },
   commentTextNone: {
     color: colors.primaryDark,
-    fontFamily: 'AvenirNext-Regular',
+    ...fonts.fontPrimaryLight,
     fontStyle: 'italic',
   },
 });
 
 const textStyle = {
   color: colors.primaryDark,
-  fontFamily: 'AvenirNext-Regular',
+  ...fonts.fontPrimaryLight,
 };
 
 const linkStyle = {
   color: colors.primaryDark,
-  fontFamily: 'AvenirNext-DemiBold',
+  ...fonts.fontPrimarySemiBold,
 };
 
 const commentStyles = StyleSheet.create({
@@ -122,7 +122,7 @@ export class CommentListItem extends Component {
             <Text
               style={{
                 color: colors.greyBlue,
-                fontFamily: 'AvenirNext-Regular',
+                ...fonts.fontPrimaryLight,
               }}
             >
               {defaultRenderer(node.children, parent)}
@@ -141,7 +141,7 @@ export class CommentListItem extends Component {
           <Text
             key={index}
             style={{
-              fontFamily: 'Menlo',
+              ...fonts.fontCode,
               backgroundColor: colors.greyMidLight,
               fontSize: normalize(11),
               margin: node.parent.name === 'pre' ? 12 : 3,
@@ -167,7 +167,7 @@ export class CommentListItem extends Component {
             <Text
               style={{
                 color: colors.primaryDark,
-                fontFamily: 'AvenirNext-DemiBold',
+                ...fonts.fontPrimarySemiBold,
                 fontSize:
                   node.name === 'h1'
                     ? normalize(24)
@@ -184,8 +184,7 @@ export class CommentListItem extends Component {
           <Text
             key={index}
             style={{
-              fontFamily: 'AvenirNext-DemiBold',
-              fontWeight: '600',
+              ...fonts.fontPrimarySemiBold,
               color: colors.primaryDark,
             }}
             onPress={() => onLinkPress(node)}

--- a/src/components/diff-blocks.component.js
+++ b/src/components/diff-blocks.component.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 
-import { colors } from 'config';
+import { colors, fonts } from 'config';
 
 type Props = {
   additions: number,
@@ -23,13 +23,13 @@ const styles = StyleSheet.create({
   },
   numAdditions: {
     marginRight: 3,
-    fontFamily: 'AvenirNext-DemiBold',
+    ...fonts.fontPrimarySemiBold,
     color: colors.green,
     letterSpacing: 1,
   },
   numDeletions: {
     marginRight: 2,
-    fontFamily: 'AvenirNext-DemiBold',
+    ...fonts.fontPrimarySemiBold,
     color: colors.red,
     letterSpacing: 1,
   },

--- a/src/components/issue-description.component.js
+++ b/src/components/issue-description.component.js
@@ -10,7 +10,7 @@ import {
   LabelButton,
   DiffBlocks,
 } from 'components';
-import { colors, normalize } from 'config';
+import { colors, fonts, normalize } from 'config';
 
 const styles = StyleSheet.create({
   headerContainer: {
@@ -25,11 +25,11 @@ const styles = StyleSheet.create({
   },
   title: {
     color: colors.primarydark,
-    fontFamily: 'AvenirNext-DemiBold',
+    ...fonts.fontPrimarySemiBold,
   },
   titleSmall: {
     color: colors.primarydark,
-    fontFamily: 'AvenirNext-DemiBold',
+    ...fonts.fontPrimarySemiBold,
     fontSize: normalize(10),
   },
   listItemContainer: {

--- a/src/components/issue-list-item.component.js
+++ b/src/components/issue-list-item.component.js
@@ -4,7 +4,7 @@ import { ListItem } from 'react-native-elements';
 import moment from 'moment';
 
 import { IssueStateBadge } from 'components';
-import { colors } from 'config';
+import { colors, fonts } from 'config';
 
 type Props = {
   type: string,
@@ -32,7 +32,7 @@ const styles = StyleSheet.create({
   },
   title: {
     color: colors.primarydark,
-    fontFamily: 'AvenirNext-Medium',
+    ...fonts.fontPrimary,
   },
   badge: {
     flex: 0.15,

--- a/src/components/issue-state-badge.component.js
+++ b/src/components/issue-state-badge.component.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Text, View, StyleSheet } from 'react-native';
 
-import { colors, normalize } from 'config';
+import { colors, fonts, normalize } from 'config';
 
 type Props = {
   issue: Object,
@@ -26,7 +26,7 @@ const styles = StyleSheet.create({
   },
   text: {
     fontSize: normalize(12),
-    fontFamily: 'AvenirNext-DemiBold',
+    ...fonts.fontPrimarySemiBold,
     color: colors.white,
   },
 });

--- a/src/components/loading-indicators/loading-container.component.js
+++ b/src/components/loading-indicators/loading-container.component.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { StyleSheet, View, ActivityIndicator, Text } from 'react-native';
 
-import { colors } from 'config';
+import { colors, fonts } from 'config';
 
 type Props = {
   animating: boolean,
@@ -22,7 +22,7 @@ const styles = StyleSheet.create({
     height: 80,
   },
   text: {
-    fontFamily: 'AvenirNext-Medium',
+    ...fonts.fontPrimary,
   },
 });
 

--- a/src/components/loading-indicators/loading-members-list.component.js
+++ b/src/components/loading-indicators/loading-members-list.component.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { StyleSheet, View, Text, Animated } from 'react-native';
 
-import { colors } from 'config';
+import { colors, fonts } from 'config';
 import { loadingAnimation } from 'utils';
 
 const styles = StyleSheet.create({
@@ -22,7 +22,7 @@ const styles = StyleSheet.create({
   },
   sectionTitle: {
     color: colors.black,
-    fontFamily: 'AvenirNext-Bold',
+    ...fonts.fontPrimaryBold,
     marginBottom: 10,
   },
 });

--- a/src/components/loading-indicators/loading-repository-profile.component.js
+++ b/src/components/loading-indicators/loading-repository-profile.component.js
@@ -4,7 +4,7 @@ import React, { Component } from 'react';
 import { StyleSheet, Text, View, Animated } from 'react-native';
 import { Icon } from 'react-native-elements';
 
-import { colors, normalize } from 'config';
+import { colors, fonts, normalize } from 'config';
 import { loadingAnimation } from 'utils';
 
 const styles = StyleSheet.create({
@@ -24,15 +24,14 @@ const styles = StyleSheet.create({
   },
   title: {
     color: colors.white,
-    fontFamily: 'AvenirNext-Bold',
+    ...fonts.fontPrimaryBold,
     fontSize: normalize(16),
-    fontWeight: 'bold',
     marginBottom: 2,
     backgroundColor: 'transparent',
   },
   subtitle: {
     color: colors.white,
-    fontFamily: 'AvenirNext-Medium',
+    ...fonts.fontPrimary,
     fontSize: normalize(12),
     paddingLeft: 15,
     paddingRight: 15,
@@ -51,7 +50,7 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     color: colors.white,
     fontSize: normalize(10),
-    fontFamily: 'AvenirNext-Medium',
+    ...fonts.fontPrimary,
   },
   icon: {
     paddingBottom: 20,

--- a/src/components/members.component.js
+++ b/src/components/members.component.js
@@ -9,7 +9,7 @@ import {
   Image,
 } from 'react-native';
 
-import { colors } from 'config';
+import { colors, fonts } from 'config';
 
 type Props = {
   title: string,
@@ -35,12 +35,12 @@ const styles = StyleSheet.create({
   },
   sectionTitle: {
     color: colors.black,
-    fontFamily: 'AvenirNext-Bold',
+    ...fonts.fontPrimaryBold,
     marginBottom: 10,
   },
   sectionTitleSmall: {
     color: colors.primarydark,
-    fontFamily: 'AvenirNext-DemiBold',
+    ...fonts.fontPrimarySemiBold,
     marginBottom: 10,
   },
 });

--- a/src/components/notification-list-item.component.js
+++ b/src/components/notification-list-item.component.js
@@ -4,7 +4,7 @@ import React from 'react';
 import { StyleSheet, View, TouchableOpacity, Text } from 'react-native';
 import { Icon } from 'react-native-elements';
 
-import { colors, normalize } from 'config';
+import { colors, fonts, normalize } from 'config';
 
 type Props = {
   notification: Object,
@@ -37,7 +37,7 @@ const styles = StyleSheet.create({
   },
   title: {
     color: colors.black,
-    fontFamily: 'AvenirNext-Medium',
+    ...fonts.fontPrimary,
     fontSize: normalize(12),
     marginLeft: 10,
   },

--- a/src/components/parallax-scroll.component.js
+++ b/src/components/parallax-scroll.component.js
@@ -3,7 +3,7 @@ import { View, Text, Dimensions, StyleSheet } from 'react-native';
 import ParallaxScrollView from 'react-native-parallax-scroll-view';
 import { Icon } from 'react-native-elements';
 
-import { colors, normalize } from 'config';
+import { colors, fonts, normalize } from 'config';
 
 const window = Dimensions.get('window');
 const PARALLAX_HEADER_HEIGHT = window.height / 2;
@@ -36,9 +36,8 @@ const styles = StyleSheet.create({
   },
   stickySectionText: {
     color: colors.white,
-    fontFamily: 'AvenirNext-Bold',
+    ...fonts.fontPrimaryBold,
     fontSize: normalize(16),
-    fontWeight: 'bold',
     margin: 10,
   },
   fixedSectionLeft: {

--- a/src/components/repository-list-item.component.js
+++ b/src/components/repository-list-item.component.js
@@ -3,7 +3,7 @@ import { StyleSheet, Text, View } from 'react-native';
 import { ListItem, Icon } from 'react-native-elements';
 
 import { emojifyText } from 'utils';
-import { colors, languageColors, normalize } from 'config';
+import { colors, languageColors, fonts, normalize } from 'config';
 
 type Props = {
   repository: Object,
@@ -21,7 +21,7 @@ const styles = StyleSheet.create({
   },
   title: {
     color: colors.primarydark,
-    fontFamily: 'AvenirNext-DemiBold',
+    ...fonts.fontPrimarySemiBold,
   },
   private: {
     borderColor: 'rgba(27, 31, 35, 0.15)',
@@ -37,7 +37,7 @@ const styles = StyleSheet.create({
   },
   description: {
     color: colors.primaryDark,
-    fontFamily: 'AvenirNext-Regular',
+    ...fonts.fontPrimaryLight,
   },
   extraInfo: {
     flexDirection: 'row',
@@ -49,7 +49,7 @@ const styles = StyleSheet.create({
     paddingLeft: 3,
     marginRight: 15,
     fontSize: normalize(10),
-    fontFamily: 'AvenirNext-Medium',
+    ...fonts.fontPrimary,
   },
   repositoryContainer: {
     justifyContent: 'center',

--- a/src/components/repository-profile.component.js
+++ b/src/components/repository-profile.component.js
@@ -3,7 +3,7 @@ import { StyleSheet, Text, View } from 'react-native';
 import { Icon } from 'react-native-elements';
 
 import { emojifyText } from 'utils';
-import { colors, normalize } from 'config';
+import { colors, fonts, normalize } from 'config';
 
 type Props = {
   repository: Object,
@@ -27,15 +27,14 @@ const styles = StyleSheet.create({
   },
   title: {
     color: colors.white,
-    fontFamily: 'AvenirNext-Bold',
+    ...fonts.fontPrimaryBold,
     fontSize: normalize(16),
-    fontWeight: 'bold',
     marginBottom: 2,
     backgroundColor: 'transparent',
   },
   subtitle: {
     color: colors.white,
-    fontFamily: 'AvenirNext-Medium',
+    ...fonts.fontPrimary,
     fontSize: normalize(12),
     paddingLeft: 15,
     paddingRight: 15,
@@ -60,15 +59,14 @@ const styles = StyleSheet.create({
   unitNumber: {
     textAlign: 'center',
     color: colors.white,
-    fontFamily: 'AvenirNext-Bold',
+    ...fonts.fontPrimaryBold,
     fontSize: normalize(16),
-    fontWeight: 'bold',
   },
   unitText: {
     textAlign: 'center',
     color: colors.white,
     fontSize: normalize(10),
-    fontFamily: 'AvenirNext-Medium',
+    ...fonts.fontPrimary,
   },
   green: {
     color: colors.lightGreen,
@@ -108,7 +106,7 @@ export const RepositoryProfile = ({ repository, starred, navigation }: Props) =>
                 <Text>
                   <Text>forked from</Text>
                   <Text
-                    style={{ fontWeight: 'bold' }}
+                    style={{ fontFamily: 'AvenirNext-Bold' }}
                     onPress={() =>
                       navigation.navigate('Repository', {
                         repository: repository.parent,

--- a/src/components/section-list.component.js
+++ b/src/components/section-list.component.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { StyleSheet, Text, View, ActivityIndicator } from 'react-native';
 import { List, ListItem, Button } from 'react-native-elements';
 
-import { colors } from 'config';
+import { colors, fonts } from 'config';
 
 type Props = {
   loading: boolean,
@@ -29,11 +29,11 @@ const styles = StyleSheet.create({
   sectionTitle: {
     color: colors.black,
     padding: 15,
-    fontFamily: 'AvenirNext-Bold',
+    ...fonts.fontPrimaryBold,
   },
   listTitle: {
     color: colors.black,
-    fontFamily: 'AvenirNext-Medium',
+    ...fonts.fontPrimary,
   },
   button: {
     backgroundColor: colors.white,

--- a/src/components/user-list-item.component.js
+++ b/src/components/user-list-item.component.js
@@ -9,7 +9,7 @@ import {
 } from 'react-native';
 import { Icon } from 'react-native-elements';
 
-import { colors, normalize } from 'config';
+import { colors, fonts, normalize } from 'config';
 
 type Props = {
   user: Object,
@@ -49,7 +49,7 @@ const styles = StyleSheet.create({
   },
   title: {
     color: colors.black,
-    fontFamily: 'AvenirNext-Medium',
+    ...fonts.fontPrimary,
     fontSize: normalize(14),
     marginLeft: 10,
   },
@@ -57,7 +57,7 @@ const styles = StyleSheet.create({
     color: colors.greyDark,
     fontSize: normalize(10),
     marginTop: 1,
-    fontWeight: '600',
+    ...fonts.fontPrimarySemiBold,
     marginLeft: 10,
   },
   iconContainer: {

--- a/src/components/user-profile.component.js
+++ b/src/components/user-profile.component.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { StyleSheet, Text, View, TouchableOpacity, Image } from 'react-native';
 
-import { colors, normalize } from 'config';
+import { colors, fonts, normalize } from 'config';
 
 type Props = {
   type: string,
@@ -34,14 +34,13 @@ const styles = StyleSheet.create({
   },
   title: {
     color: colors.white,
-    fontFamily: 'AvenirNext-Bold',
+    ...fonts.fontPrimaryBold,
     fontSize: normalize(16),
-    fontWeight: 'bold',
     marginBottom: 2,
   },
   subtitle: {
     color: colors.white,
-    fontFamily: 'AvenirNext-Medium',
+    ...fonts.fontPrimary,
     fontSize: normalize(12),
     marginBottom: 50,
     paddingLeft: 15,
@@ -58,15 +57,14 @@ const styles = StyleSheet.create({
   unitNumber: {
     textAlign: 'center',
     color: colors.white,
-    fontFamily: 'AvenirNext-Bold',
+    ...fonts.fontPrimaryBold,
     fontSize: normalize(16),
-    fontWeight: 'bold',
   },
   unitText: {
     textAlign: 'center',
     color: colors.white,
     fontSize: normalize(10),
-    fontFamily: 'AvenirNext-Medium',
+    ...fonts.fontPrimary,
   },
   green: {
     color: colors.lightGreen,

--- a/src/config/fonts.js
+++ b/src/config/fonts.js
@@ -1,0 +1,19 @@
+import { Platform } from 'react-native';
+
+const iosFonts = {
+  fontPrimaryLight: { fontFamily: 'AvenirNext-Regular' },
+  fontPrimary: { fontFamily: 'AvenirNext-Medium' },
+  fontPrimarySemiBold: { fontFamily: 'AvenirNext-DemiBold' },
+  fontPrimaryBold: { fontFamily: 'AvenirNext-Bold' },
+  fontCode: { fontFamily: 'Menlo' },
+};
+
+const androidFonts = {
+  fontPrimaryLight: { fontFamily: 'sans-serif-light' },
+  fontPrimary: { fontFamily: 'sans-serif' },
+  fontPrimarySemiBold: { fontFamily: 'sans-serif-medium' },
+  fontPrimaryBold: { fontFamily: 'sans-serif-medium' },
+  fontCode: { fontFamily: 'Roboto' },
+};
+
+export const fonts = Platform.OS === 'ios' ? iosFonts : androidFonts;

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,2 +1,3 @@
 export * from './colors';
+export * from './fonts';
 export * from './normalize-text';

--- a/src/issue/screens/issue-settings.screen.js
+++ b/src/issue/screens/issue-settings.screen.js
@@ -10,7 +10,7 @@ import {
   UserListItem,
   LabelListItem,
 } from 'components';
-import { colors } from 'config';
+import { colors, fonts } from 'config';
 import { getLabels } from 'repository';
 import { editIssue, changeIssueLockStatus } from '../issue.action';
 
@@ -35,15 +35,15 @@ const mapDispatchToProps = dispatch => ({
 const styles = StyleSheet.create({
   listItemTitle: {
     color: colors.black,
-    fontFamily: 'AvenirNext-Medium',
+    ...fonts.fontPrimary,
   },
   closeActionTitle: {
     color: colors.red,
-    fontFamily: 'AvenirNext-Medium',
+    ...fonts.fontPrimary,
   },
   openActionTitle: {
     color: colors.green,
-    fontFamily: 'AvenirNext-Medium',
+    ...fonts.fontPrimary,
   },
 });
 

--- a/src/issue/screens/pull-merge.screen.js
+++ b/src/issue/screens/pull-merge.screen.js
@@ -5,7 +5,7 @@ import { ListItem, Icon } from 'react-native-elements';
 import ActionSheet from 'react-native-actionsheet';
 
 import { ViewContainer, SectionList } from 'components';
-import { colors, normalize } from 'config';
+import { colors, fonts, normalize } from 'config';
 import { mergePullRequest } from '../issue.action';
 
 const mapStateToProps = state => ({
@@ -36,18 +36,18 @@ const mapDispatchToProps = dispatch => ({
 const styles = StyleSheet.create({
   listItemTitle: {
     color: colors.black,
-    fontFamily: 'AvenirNext-Medium',
+    ...fonts.fontPrimary,
   },
   textInput: {
     fontSize: normalize(12),
     marginHorizontal: 15,
     flex: 1,
     color: colors.black,
-    fontFamily: 'AvenirNext-Regular',
+    ...fonts.fontPrimaryLight,
   },
   mergeActionTitle: {
     color: colors.green,
-    fontFamily: 'AvenirNext-Medium',
+    ...fonts.fontPrimary,
   },
   mergeListItemContainer: {
     flexDirection: 'row',

--- a/src/notifications/screens/notifications.screen.js
+++ b/src/notifications/screens/notifications.screen.js
@@ -17,7 +17,7 @@ import {
   LoadingContainer,
   NotificationListItem,
 } from 'components';
-import { colors, normalize } from 'config';
+import { colors, fonts, normalize } from 'config';
 import { getIssueFromUrl } from 'issue';
 import {
   getUnreadNotifications,
@@ -57,7 +57,7 @@ const styles = StyleSheet.create({
     height: 30,
   },
   buttonGroupText: {
-    fontFamily: 'AvenirNext-Bold',
+    ...fonts.fontPrimaryBold,
   },
   buttonGroupTextSelected: {
     color: colors.black,
@@ -80,14 +80,14 @@ const styles = StyleSheet.create({
   },
   repositoryTitle: {
     color: colors.primarydark,
-    fontFamily: 'AvenirNext-DemiBold',
+    ...fonts.fontPrimarySemiBold,
     marginLeft: 10,
     flex: 1,
   },
   notificationTitle: {
     color: colors.black,
     fontSize: normalize(12),
-    fontFamily: 'AvenirNext-Regular',
+    ...fonts.fontPrimaryLight,
   },
   markAsReadIconRepo: {
     flex: 0.15,
@@ -106,7 +106,7 @@ const styles = StyleSheet.create({
   noneTitle: {
     fontSize: normalize(16),
     textAlign: 'center',
-    fontFamily: 'AvenirNext-Medium',
+    ...fonts.fontPrimary,
   },
 });
 

--- a/src/organization/screens/organization-profile.screen.js
+++ b/src/organization/screens/organization-profile.screen.js
@@ -12,7 +12,7 @@ import {
   SectionList,
   ParallaxScroll,
 } from 'components';
-import { colors } from 'config';
+import { colors, fonts } from 'config';
 import { getOrg, getOrgRepos, getOrgMembers } from '../index';
 
 const mapStateToProps = state => ({
@@ -33,7 +33,7 @@ const mapDispatchToProps = dispatch => ({
 const styles = StyleSheet.create({
   listTitle: {
     color: colors.black,
-    fontFamily: 'AvenirNext-Medium',
+    ...fonts.fontPrimary,
   },
 });
 

--- a/src/repository/screens/issue-list.screen.js
+++ b/src/repository/screens/issue-list.screen.js
@@ -9,7 +9,7 @@ import {
   SearchBar,
 } from 'components';
 
-import { colors, normalize } from 'config';
+import { colors, fonts, normalize } from 'config';
 import {
   searchOpenRepoIssues,
   searchClosedRepoIssues,
@@ -50,7 +50,7 @@ const styles = StyleSheet.create({
     height: 30,
   },
   buttonGroupText: {
-    fontFamily: 'AvenirNext-Bold',
+    ...fonts.fontPrimaryBold,
   },
   buttonGroupTextSelected: {
     color: colors.black,

--- a/src/repository/screens/pull-diff.screen.js
+++ b/src/repository/screens/pull-diff.screen.js
@@ -5,7 +5,7 @@ import { Card } from 'react-native-elements';
 import Parse from 'parse-diff';
 
 import { ViewContainer, DiffBlocks, CodeLine } from 'components';
-import { colors, normalize } from 'config';
+import { colors, fonts, normalize } from 'config';
 
 const styles = StyleSheet.create({
   fileChangeContainer: {
@@ -25,7 +25,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   lineNumbersChanged: {
-    fontFamily: 'Menlo',
+    ...fonts.fontCode,
     marginRight: 5,
   },
   fileTitle: {
@@ -33,23 +33,23 @@ const styles = StyleSheet.create({
     marginLeft: 10,
   },
   codeStyle: {
-    fontFamily: 'Menlo',
+    ...fonts.fontCode,
     fontSize: normalize(10),
   },
   dividerStyle: {
     marginBottom: 0,
   },
   noChangesMessage: {
-    fontFamily: 'AvenirNext-DemiBold',
+    ...fonts.fontPrimarySemiBold,
     paddingVertical: 5,
     paddingLeft: 10,
   },
   newIndicator: {
-    fontFamily: 'AvenirNext-DemiBold',
+    ...fonts.fontPrimarySemiBold,
     color: colors.green,
   },
   deletedIndicator: {
-    fontFamily: 'AvenirNext-DemiBold',
+    ...fonts.fontPrimarySemiBold,
     color: colors.red,
   },
   header: {
@@ -63,7 +63,7 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   headerText: {
-    fontFamily: 'AvenirNext-DemiBold',
+    ...fonts.fontPrimarySemiBold,
     fontSize: normalize(14),
   },
 });
@@ -123,14 +123,16 @@ class PullDiff extends Component {
               key={index}
               newChunk
               change={{ content: chunk.content }}
-              filename={filename} />
+              filename={filename}
+            />
 
-            {chunk.changes.map((change, changesIndex) => (
+            {chunk.changes.map((change, changesIndex) =>
               <CodeLine
                 key={changesIndex}
                 change={change}
-                filename={filename} />
-            ))}
+                filename={filename}
+              />
+            )}
           </View>
         </ScrollView>
       );

--- a/src/repository/screens/pull-list.screen.js
+++ b/src/repository/screens/pull-list.screen.js
@@ -9,7 +9,7 @@ import {
   SearchBar,
 } from 'components';
 
-import { colors, normalize } from 'config';
+import { colors, fonts, normalize } from 'config';
 import {
   searchOpenRepoPulls,
   searchClosedRepoPulls,
@@ -50,7 +50,7 @@ const styles = StyleSheet.create({
     height: 30,
   },
   buttonGroupText: {
-    fontFamily: 'AvenirNext-Bold',
+    ...fonts.fontPrimaryBold,
   },
   buttonGroupTextSelected: {
     color: colors.black,

--- a/src/repository/screens/repository-code-list.screen.js
+++ b/src/repository/screens/repository-code-list.screen.js
@@ -4,7 +4,7 @@ import { StyleSheet, FlatList, View, Text } from 'react-native';
 import { ListItem } from 'react-native-elements';
 
 import { ViewContainer, LoadingListItem } from 'components';
-import { colors, normalize } from 'config';
+import { colors, fonts, normalize } from 'config';
 import { getContents } from '../repository.action';
 
 const mapStateToProps = state => ({
@@ -20,11 +20,11 @@ const mapDispatchToProps = dispatch => ({
 const styles = StyleSheet.create({
   title: {
     color: colors.black,
-    fontFamily: 'AvenirNext-Regular',
+    ...fonts.fontPrimaryLight,
   },
   titleBold: {
     color: colors.black,
-    fontFamily: 'AvenirNext-DemiBold',
+    ...fonts.fontPrimarySemiBold,
   },
   textContainer: {
     flex: 1,

--- a/src/repository/screens/repository-file.screen.js
+++ b/src/repository/screens/repository-file.screen.js
@@ -14,7 +14,7 @@ import { getLanguage } from 'lowlight';
 import { github as GithubStyle } from 'react-syntax-highlighter/dist/styles';
 
 import { ViewContainer, LoadingContainer } from 'components';
-import { colors, normalize } from 'config';
+import { colors, fonts, normalize } from 'config';
 import { getRepositoryFile } from '../repository.action';
 
 const mapStateToProps = state => ({
@@ -47,7 +47,7 @@ const styles = StyleSheet.create({
   },
   headerText: {
     color: colors.primaryDark,
-    fontFamily: 'AvenirNext-DemiBold',
+    ...fonts.fontPrimarySemiBold,
     fontSize: normalize(12),
   },
   content: {
@@ -55,7 +55,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: 10,
   },
   contentText: {
-    fontFamily: 'Menlo',
+    ...fonts.fontCode,
     fontSize: normalize(10),
   },
   contentCode: {

--- a/src/repository/screens/repository.screen.js
+++ b/src/repository/screens/repository.screen.js
@@ -17,7 +17,7 @@ import {
   LoadingMembersList,
   LoadingModal,
 } from 'components';
-import { colors } from 'config';
+import { colors, fonts } from 'config';
 import {
   getRepositoryInfo,
   getContributors,
@@ -52,7 +52,7 @@ const mapDispatchToProps = dispatch => ({
 const styles = StyleSheet.create({
   listTitle: {
     color: colors.black,
-    fontFamily: 'AvenirNext-Medium',
+    ...fonts.fontPrimary,
   },
 });
 

--- a/src/search/screens/search.screen.js
+++ b/src/search/screens/search.screen.js
@@ -10,7 +10,7 @@ import {
   LoadingContainer,
   SearchBar,
 } from 'components';
-import { colors, normalize } from 'config';
+import { colors, fonts, normalize } from 'config';
 import { searchRepos, searchUsers } from '../index';
 
 const mapStateToProps = state => ({
@@ -42,7 +42,7 @@ const styles = StyleSheet.create({
     height: 30,
   },
   buttonGroupText: {
-    fontFamily: 'AvenirNext-Bold',
+    ...fonts.fontPrimaryBold,
   },
   buttonGroupTextSelected: {
     color: colors.black,
@@ -59,7 +59,7 @@ const styles = StyleSheet.create({
   searchTitle: {
     fontSize: normalize(18),
     textAlign: 'center',
-    fontFamily: 'AvenirNext-Medium',
+    ...fonts.fontPrimary,
   },
   searchCancelButton: {
     color: colors.black,

--- a/src/user/screens/profile.screen.js
+++ b/src/user/screens/profile.screen.js
@@ -12,7 +12,7 @@ import {
   ParallaxScroll,
   UserListItem,
 } from 'components';
-import { colors } from 'config';
+import { colors, fonts } from 'config';
 import { getUserInfo, changeFollowStatus } from '../user.action';
 
 const mapStateToProps = state => ({
@@ -33,11 +33,11 @@ const mapDispatchToProps = dispatch => ({
 const styles = StyleSheet.create({
   listTitle: {
     color: colors.black,
-    fontFamily: 'AvenirNext-Medium',
+    ...fonts.fontPrimary,
   },
   listSubTitle: {
     color: colors.greyDark,
-    fontFamily: 'AvenirNext-Medium',
+    ...fonts.fontPrimary,
   },
 });
 


### PR DESCRIPTION
For #87 

Added a separate `fonts` config file to expose separate font objects for iOS/Android. This PR uses the built-in Android font `sans-serif`:

![image](https://user-images.githubusercontent.com/12476932/28250346-e44a6850-6a33-11e7-81d3-464b14d6fd54.png)

Looks decent I think but also thinking of importing a custom font if we can find one that's better (Android [default font list](https://github.com/react-native-training/react-native-fonts) isn't as large as iOS)

Open to all kinds of suggestions and tips 🙌 