### PR TITLE
Android fonts - Fix #121

### DIFF
--- a/src/components/code-line.component.js
+++ b/src/components/code-line.component.js
@@ -22,7 +22,7 @@ const styles = StyleSheet.create({
   },
   codeLine: {
     ...fonts.fontCode,
-    fontSize: normalize(10),
+    fontSize: normalize(11),
     paddingHorizontal: 10,
     paddingVertical: 3,
   },
@@ -56,7 +56,7 @@ const styles = StyleSheet.create({
   },
   codeLineNumber: {
     ...fonts.fontCode,
-    fontSize: normalize(10),
+    fontSize: normalize(11),
     flex: 1,
     alignItems: 'center',
     color: colors.grey,
@@ -131,6 +131,7 @@ export class CodeLine extends Component {
                 codeTagProps={{ style: styles.codeLine }}
                 customStyle={customStyle}
                 fontFamily={fonts.fontCode.fontFamily}
+                fontSize={styles.codeLine.fontSize}
               >
                 {change.content}
               </SyntaxHighlighter>}

--- a/src/components/code-line.component.js
+++ b/src/components/code-line.component.js
@@ -130,6 +130,7 @@ export class CodeLine extends Component {
                 CodeTag={Text}
                 codeTagProps={{ style: styles.codeLine }}
                 customStyle={customStyle}
+                fontFamily={fonts.fontCode.fontFamily}
               >
                 {change.content}
               </SyntaxHighlighter>}

--- a/src/config/fonts.js
+++ b/src/config/fonts.js
@@ -9,10 +9,10 @@ const iosFonts = {
 };
 
 const androidFonts = {
-  fontPrimaryLight: { fontFamily: 'OpensSans-Light', fontWeight: '300' },
-  fontPrimary: { fontFamily: 'OpensSans-Regular' },
-  fontPrimarySemiBold: { fontFamily: 'OpensSans-SemiBold', fontWeight: '600' },
-  fontPrimaryBold: { fontFamily: 'OpensSans-Bold', fontWeight: '700' },
+  fontPrimaryLight: { fontFamily: 'OpenSans-Light', fontWeight: '300' },
+  fontPrimary: { fontFamily: 'OpenSans-Regular' },
+  fontPrimarySemiBold: { fontFamily: 'OpenSans-SemiBold', fontWeight: '600' },
+  fontPrimaryBold: { fontFamily: 'OpenSans-Bold', fontWeight: '700' },
   fontCode: { fontFamily: 'Menlo' },
 };
 

--- a/src/repository/screens/repository-file.screen.js
+++ b/src/repository/screens/repository-file.screen.js
@@ -176,7 +176,7 @@ class RepositoryFile extends Component {
                     CodeTag={Text}
                     codeTagProps={{ style: styles.contentCode }}
                     style={GithubStyle}
-                    fontFamily={styles.contentText.fontFamily}
+                    fontFamily={fonts.fontCode.fontFamily}
                     fontSize={styles.contentText.fontSize}
                   >
                     {fileContent}


### PR DESCRIPTION
This one should apply `Menlo` font to code preview. It also fix a typo with `OpenSans` declaration.

I said **should** because I can't see a big difference on my screen...