### PR TITLE
[WIP] Opening the profile avatar in full size by click. Closes #7

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -135,6 +135,7 @@ android {
 }
 
 dependencies {
+    compile project(':react-native-photo-view')
     compile project(':react-native-config')
     compile project(':react-native-code-push')
     compile project(':react-native-device-info')

--- a/android/app/src/main/java/com/gitpoint/MainApplication.java
+++ b/android/app/src/main/java/com/gitpoint/MainApplication.java
@@ -3,6 +3,7 @@ package com.gitpoint;
 import android.app.Application;
 
 import com.facebook.react.ReactApplication;
+import com.reactnative.photoview.PhotoViewPackage;
 import com.lugg.ReactNativeConfig.ReactNativeConfigPackage;
 import com.microsoft.codepush.react.CodePush;
 import com.learnium.RNDeviceInfo.RNDeviceInfo;
@@ -33,6 +34,7 @@ public class MainApplication extends Application implements ReactApplication {
     protected List<ReactPackage> getPackages() {
       return Arrays.<ReactPackage>asList(
           new MainReactPackage(),
+            new PhotoViewPackage(),
             new ReactNativeConfigPackage(),
             new CodePush(BuildConfig.CODEPUSH_ANDROID_DEPLOYMENT_KEY, MainApplication.this, BuildConfig.DEBUG),
             new RNDeviceInfo(),

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,4 +1,6 @@
 rootProject.name = 'GitPoint'
+include ':react-native-photo-view'
+project(':react-native-photo-view').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-photo-view/android')
 include ':react-native-config'
 project(':react-native-config').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-config/android')
 include ':react-native-code-push'

--- a/ios/GitPoint.xcodeproj/project.pbxproj
+++ b/ios/GitPoint.xcodeproj/project.pbxproj
@@ -5,7 +5,6 @@
 	};
 	objectVersion = 46;
 	objects = {
-
 /* Begin PBXBuildFile section */
 		00C302E51ABCBA2D00DB3ED1 /* libRCTActionSheet.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302AC1ABCB8CE00DB3ED1 /* libRCTActionSheet.a */; };
 		00C302E71ABCBA2D00DB3ED1 /* libRCTGeolocation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302BA1ABCB90400DB3ED1 /* libRCTGeolocation.a */; };

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "lint-pass"
   ],
   "dependencies": {
+    "lodash.uniqby": "^4.7.0",
     "lowlight": "^1.5.0",
     "md5": "^2.2.1",
     "moment": "^2.17.1",
@@ -59,6 +60,7 @@
     "react-native-htmlview": "^0.11.1",
     "react-native-material-design-searchbar": "^1.1.4",
     "react-native-parallax-scroll-view": "^0.19.0",
+    "react-native-photo-view": "^1.3.0",
     "react-native-safari-view": "^2.0.0",
     "react-native-search-bar": "^3.0.0",
     "react-native-syntax-highlighter": "^1.2.1",
@@ -70,8 +72,7 @@
     "redux-logger": "^2.7.4",
     "redux-persist": "^4.3.1",
     "redux-persist-transform-encrypt": "^1.0.2",
-    "redux-thunk": "^2.2.0",
-    "lodash.uniqby": "^4.7.0"
+    "redux-thunk": "^2.2.0"
   },
   "devDependencies": {
     "all-contributors-cli": "^4.3.0",
@@ -81,6 +82,7 @@
     "babel-plugin-transform-inline-environment-variables": "^6.8.0",
     "babel-preset-flow": "^6.23.0",
     "babel-preset-react-native": "1.9.1",
+    "concurrently": "^3.5.0",
     "eslint": "^3.19.0",
     "eslint-config-airbnb": "^15.0.2",
     "eslint-config-airbnb-base": "~11.2.0",
@@ -95,8 +97,7 @@
     "lint-staged": "^3.2.6",
     "pre-commit": "^1.2.2",
     "prettier": "^1.3.1",
-    "react-test-renderer": "16.0.0-alpha.6",
-    "concurrently": "^3.5.0"
+    "react-test-renderer": "16.0.0-alpha.6"
   },
   "jest": {
     "preset": "react-native"

--- a/src/components/image-zoom.component.js
+++ b/src/components/image-zoom.component.js
@@ -1,0 +1,86 @@
+import React, { Component } from 'react';
+import {
+  StyleSheet,
+  Image,
+  View,
+  Modal,
+  Dimensions,
+  TouchableOpacity,
+  TouchableHighlight,
+} from 'react-native';
+import { Icon } from 'react-native-elements';
+import PhotoView from 'react-native-photo-view';
+
+import { colors } from 'config';
+
+const styles = StyleSheet.create({
+  modalContainer: {
+    flex: 1,
+    backgroundColor: colors.black,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  closeButton: {
+    position: 'absolute',
+    top: 30,
+    right: 10,
+  },
+});
+
+export class ImageZoom extends Component {
+  props: {
+    uri: string,
+    style: Object,
+  };
+
+  constructor() {
+    super();
+    this.state = {
+      imgZoom: false,
+    };
+  }
+
+  openModal() {
+    this.setState({ imgZoom: true });
+  }
+
+  closeModal() {
+    this.setState({ imgZoom: false });
+  }
+
+  render() {
+    const window = Dimensions.get('window');
+    const { uri, style } = this.props;
+
+    if (this.state.imgZoom) {
+      return (
+        <Modal animationType={'fade'}>
+          <View style={styles.modalContainer}>
+            <PhotoView
+              resizeMode={'contain'}
+              onTap={() => this.closeModal()}
+              source={uri}
+              minimumZoomScale={0.5}
+              maximumZoomScale={3}
+              style={{ width: window.width, height: window.height }}
+            />
+
+            <TouchableOpacity
+              activeOpacity={0.5}
+              onPress={() => this.closeModal()}
+              style={styles.closeButton}
+            >
+              <Icon color={colors.white} size={28} name="x" type="octicon" />
+            </TouchableOpacity>
+          </View>
+        </Modal>
+      );
+    }
+
+    return (
+      <TouchableHighlight onPress={() => this.openModal()}>
+        <Image style={style} source={uri} />
+      </TouchableHighlight>
+    );
+  }
+}

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -21,3 +21,4 @@ export * from './state-badge.component';
 export * from './user-list-item.component';
 export * from './user-profile.component';
 export * from './view-container.component';
+export * from './image-zoom.component';

--- a/src/components/user-profile.component.js
+++ b/src/components/user-profile.component.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import { StyleSheet, Text, View, TouchableOpacity, Image } from 'react-native';
-
+import { StyleSheet, Text, View, TouchableOpacity } from 'react-native';
 import { colors, fonts, normalize } from 'config';
+import { ImageZoom } from 'components';
 
 type Props = {
   type: string,
@@ -80,17 +80,17 @@ export const UserProfile = ({
 }: Props) =>
   <View style={styles.container}>
     <View style={styles.profile}>
-      <Image
+      <ImageZoom
+        uri={{
+          uri: initialUser.avatar_url
+            ? initialUser.avatar_url
+            : user.avatar_url,
+        }}
         style={[
           styles.avatar,
           (initialUser.type === 'User' || user.type === 'User') &&
             styles.userAvatar,
         ]}
-        source={{
-          uri: initialUser.avatar_url
-            ? initialUser.avatar_url
-            : user.avatar_url,
-        }}
       />
       <Text style={styles.title}>
         {user.name}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4662,6 +4662,10 @@ react-native-parallax-scroll-view@^0.19.0:
   version "0.19.0"
   resolved "https://registry.yarnpkg.com/react-native-parallax-scroll-view/-/react-native-parallax-scroll-view-0.19.0.tgz#23b9af1f13249a610f4641e2582a58997df7d80a"
 
+react-native-photo-view@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/react-native-photo-view/-/react-native-photo-view-1.3.0.tgz#865974d93a9dd15e772e93fee074125b0b6909d3"
+
 react-native-safari-view@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/react-native-safari-view/-/react-native-safari-view-2.0.0.tgz#3aeb40693b0765df16b9beaf8654b60c7ff1d7ed"


### PR DESCRIPTION
When clicking on the avatar, the full size of the picture opens in the modal window (closes #7).

![image](https://user-images.githubusercontent.com/4408379/28449291-3b016548-6de7-11e7-8672-f2bacd88e97e.png)

Important note: I tested the work only on Android, **please see how it works on iOS**.

Also considered the use of the library:
[react-native-lightbox](https://github.com/oblador/react-native-lightbox) - slows opening on Android
[react-native-zoom-image](https://github.com/Tinysymphony/react-native-zoom-image ) - works fine, but does not apply to miniature styles (`borderRadius` in particular)

Therefore, I had to make my own component, using the built-in component `Modal` and PhotoView.