### PR TITLE
Better UI for long repository description;

### DIFF
--- a/src/components/repository-profile.component.js
+++ b/src/components/repository-profile.component.js
@@ -122,7 +122,6 @@ export const RepositoryProfile = ({ repository, starred, navigation }: Props) =>
       </Text>
 
       <Text
-        /* @see https://github.com/gitpoint/git-point/issues/114 */
         numberOfLines={5}
         style={[
           styles.subtitle,

--- a/src/components/repository-profile.component.js
+++ b/src/components/repository-profile.component.js
@@ -36,8 +36,8 @@ const styles = StyleSheet.create({
     color: colors.white,
     ...fonts.fontPrimary,
     fontSize: normalize(12),
-    paddingLeft: 15,
-    paddingRight: 15,
+    paddingLeft: 30,
+    paddingRight: 30,
     backgroundColor: 'transparent',
   },
   subtitleDescriptionNoFork: {
@@ -123,6 +123,8 @@ export const RepositoryProfile = ({ repository, starred, navigation }: Props) =>
       </Text>
 
       <Text
+        /* @see https://github.com/gitpoint/git-point/issues/114 */
+        numberOfLines={5}
         style={[
           styles.subtitle,
           repository.fork

--- a/src/components/repository-profile.component.js
+++ b/src/components/repository-profile.component.js
@@ -36,8 +36,7 @@ const styles = StyleSheet.create({
     color: colors.white,
     ...fonts.fontPrimary,
     fontSize: normalize(12),
-    paddingLeft: 30,
-    paddingRight: 30,
+    paddingHorizontal: 30,
     backgroundColor: 'transparent',
   },
   subtitleDescriptionNoFork: {


### PR DESCRIPTION
These are small bits of UI improvement related to #114 😄 

This is how the long title looks like with changes:
<img src="https://monosnap.com/file/TH4KMJjXTEjYoy8TBnX8p8V57PJDt6.png" width=320>

I've changed the margin left & right to `30` and instead of truncating string programatically decided to use `numberOfLines` props of `Text`.