### PR TITLE
Render member events properly

### DIFF
--- a/src/auth/screens/events.screen.js
+++ b/src/auth/screens/events.screen.js
@@ -132,7 +132,7 @@ class Events extends Component {
       case 'IssuesEvent':
         return `${userEvent.payload.action} issue`;
       case 'MemberEvent':
-        return `${userEvent.payload.action} user`;
+        return `${userEvent.payload.action}`;
       case 'PublicEvent':
         return 'open sourced';
       case 'PullRequestEvent':
@@ -387,6 +387,8 @@ class Events extends Component {
         return 'at';
       case 'PushEvent':
         return 'at';
+      case 'MemberEvent':
+        return 'to';
       default:
         return null;
     }
@@ -485,6 +487,24 @@ class Events extends Component {
           </Text>
         );
       case 'PushEvent':
+        return (
+          <Text
+            style={styles.linkDescription}
+            onPress={() =>
+              this.props.navigation.navigate('Repository', {
+                repository: {
+                  ...userEvent.repo,
+                  name: userEvent.repo.name.substring(
+                    userEvent.repo.name.indexOf('/') + 1
+                  ),
+                },
+              })}
+          >
+            {userEvent.repo.name}
+          </Text>
+        );
+
+      case 'MemberEvent':
         return (
           <Text
             style={styles.linkDescription}


### PR DESCRIPTION
I noticed that the 'Member' events were not rendered/displayed correctly. It didn't show the repository the user was added to.

![events_scren](http://preview.ibb.co/dzL1Kk/UNADJUSTEDNONRAW_thumb_1b40.jpg)

This is how it looks with the fix:

![events_screen_fixed](http://preview.ibb.co/c54aC5/Screen_Shot_2017_07_23_at_08_11_56.png)

Which is in the same style as Github shows it. 

![github_events](http://preview.ibb.co/g1fe5Q/Screen_Shot_2017_07_23_at_08_04_20.png)