### PR TITLE
Hide some elements while repo is still loading

### DIFF
--- a/src/components/repository-section-title.component.js
+++ b/src/components/repository-section-title.component.js
@@ -21,6 +21,7 @@ const styles = StyleSheet.create({
   },
   badgeContainer: {
     flexDirection: 'row',
+    marginTop: -7,
   },
   badge: {
     marginLeft: 10,

--- a/src/components/section-list.component.js
+++ b/src/components/section-list.component.js
@@ -42,7 +42,7 @@ const styles = StyleSheet.create({
     borderRadius: 3,
     paddingVertical: 5,
     paddingHorizontal: 10,
-    margin: 0,
+    marginTop: -8,
   },
   list: {
     marginTop: 0,

--- a/src/repository/screens/repository.screen.js
+++ b/src/repository/screens/repository.screen.js
@@ -250,7 +250,7 @@ class Repository extends Component {
             title={
               <RepositorySectionTitle
                 text="ISSUES"
-                loading={isPendingIssues}
+                loading={isPendingIssues || isPendingRepository}
                 openCount={openIssues.length}
                 closedCount={closedIssues.length}
               />
@@ -284,7 +284,7 @@ class Repository extends Component {
             title={
               <RepositorySectionTitle
                 text="PULL REQUESTS"
-                loading={isPendingIssues}
+                loading={isPendingIssues || isPendingRepository}
                 openCount={openPulls.length}
                 closedCount={closedPulls.length}
               />

--- a/src/repository/screens/repository.screen.js
+++ b/src/repository/screens/repository.screen.js
@@ -205,12 +205,12 @@ class Repository extends Component {
               />
             </SectionList>}
 
-          {isPendingContributors && <LoadingMembersList title="CONTRIBUTORS" />}
+          {(isPendingRepository || isPendingContributors) && <LoadingMembersList title="CONTRIBUTORS" />}
 
           {!isPendingContributors &&
             <MembersList
               title="CONTRIBUTORS"
-              members={!isPendingRepository && contributors}
+              members={contributors}
               navigation={navigation}
             />}
 

--- a/src/repository/screens/repository.screen.js
+++ b/src/repository/screens/repository.screen.js
@@ -210,7 +210,7 @@ class Repository extends Component {
           {!isPendingContributors &&
             <MembersList
               title="CONTRIBUTORS"
-              members={contributors}
+              members={!isPendingRepository && contributors}
               navigation={navigation}
             />}
 


### PR DESCRIPTION
It will fix this
From GitPoint repo and then open another repo, the contributors from previous repo will retain atleast 1 second and then update it.

![simulator screen shot 23 jul 2017 9 27 32 pm](https://user-images.githubusercontent.com/5106887/28499680-dd399814-6fed-11e7-950d-1062ded1bea6.png)
