### PR TITLE
Show zero when there are no repositories

### DIFF
--- a/src/components/user-profile.component.js
+++ b/src/components/user-profile.component.js
@@ -109,7 +109,7 @@ export const UserProfile = ({
           })}
       >
         <Text style={styles.unitNumber}>
-          {user.public_repos + (user.total_private_repos || 0) || ''}
+          {user.public_repos + (user.total_private_repos || 0) || 0}
         </Text>
         <Text style={styles.unitText}>Repositories</Text>
       </TouchableOpacity>


### PR DESCRIPTION
A small fix, because now shows an empty string:

Before | After 
| - | -
![image](https://user-images.githubusercontent.com/4408379/28499703-9094601c-6fc4-11e7-85df-fad81ef87d00.png) | ![image](https://user-images.githubusercontent.com/4408379/28499702-8cd546da-6fc4-11e7-8477-b7294792c316.png)

In this regard, I had this question: if there are no elements (repositories, followers, etc.), then we need to disable `onPress` handler, because we go to the [screen with an empty result](https://user-images.githubusercontent.com/4408379/28499729-4463f8a0-6fc5-11e7-8228-6cde0c5d32c8.png)?
