### PR TITLE
Fix displaying the list of organization's repositories

### DIFF
--- a/src/user/user.action.js
+++ b/src/user/user.action.js
@@ -123,19 +123,21 @@ export const changeFollowStatus = (user, isFollowing) => {
 export const getRepositories = user => {
   return (dispatch, getState) => {
     const { accessToken, user: authUser } = getState().auth;
+    const isAuthUser = user.login === authUser.login;
 
     dispatch({ type: GET_REPOSITORIES.PENDING });
 
-    const url =
-      user.login === authUser.login
-        ? `${apiRoot}/user`
-        : USER_ENDPOINT(user.login);
+    const url = isAuthUser ? `${apiRoot}/user` : USER_ENDPOINT(user.login);
 
     fetchUrl(`${url}/repos?per_page=50`, accessToken)
       .then(data => {
+        const payload = isAuthUser
+          ? data.filter(repo => repo.permissions.admin)
+          : data;
+
         dispatch({
           type: GET_REPOSITORIES.SUCCESS,
-          payload: data.filter(repo => repo.permissions.admin),
+          payload,
         });
       })
       .catch(error => {


### PR DESCRIPTION
Quick fix: when moving to the organization's repositories there is nothing (it broke after the changes in [this commit](https://github.com/gitpoint/git-point/commit/0eb5fd9429e1865447278b4640c1aebb33729487))

Strangely, I do not see that API returns `permissions` for repos.

1. ![image](https://user-images.githubusercontent.com/4408379/28500369-cb006902-6fcf-11e7-8ab4-3dfe58254d17.png)
2. ![image](https://user-images.githubusercontent.com/4408379/28500375-ee455738-6fcf-11e7-9e74-77621d49ed8a.png)
