### PR TITLE
Add number and type notification to title

### DIFF
--- a/routes.js
+++ b/routes.js
@@ -115,11 +115,15 @@ const sharedRoutes = {
   },
   Issue: {
     screen: IssueScreen,
-    navigationOptions: ({ navigation }) => ({
-      title: `#${navigation.state.params.issue
-        ? navigation.state.params.issue.number
-        : 'Issue'}`,
-    }),
+    navigationOptions: ({ navigation }) => {
+      const issueNumberRegex = /issues\/([0-9]+)$/;
+      const { issue, issueURL, isPR } = navigation.state.params;
+      const number = issue ? issue.number : issueURL.match(issueNumberRegex)[1];
+
+      return {
+        title: isPR ? `Pull Request #${number}` : `Issue #${number}`,
+      };
+    },
   },
   IssueSettings: {
     screen: IssueSettingsScreen,

--- a/src/notifications/screens/notifications.screen.js
+++ b/src/notifications/screens/notifications.screen.js
@@ -187,6 +187,7 @@ class Notifications extends Component {
     markAsReadByDispatch(notification.id);
     navigation.navigate('Issue', {
       issueURL: notification.subject.url.replace('pulls', 'issues'),
+      isPR: notification.subject.type === 'PullRequest',
     });
   }
 


### PR DESCRIPTION
Now the notification item have this title:
![image](https://user-images.githubusercontent.com/4408379/28540270-694ce106-70bd-11e7-9313-5b9b7415b629.png)

There is no number and type (issue or PR). So I thought it would be nice to add this:
![image](https://user-images.githubusercontent.com/4408379/28540355-c0e437ca-70bd-11e7-95b0-2df942497d8c.png)![image](https://user-images.githubusercontent.com/4408379/28540359-c4799aba-70bd-11e7-8035-beccd3550d56.png)
