### PR TITLE
Fix ordered-list 2/2

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "react-native-config": "^0.5.0",
     "react-native-device-info": "^0.10.2",
     "react-native-elements": "^0.9.3",
-    "react-native-htmlview": "^0.11.1",
+    "react-native-htmlview": "^0.12.0",
     "react-native-material-design-searchbar": "^1.1.4",
     "react-native-parallax-scroll-view": "^0.19.0",
     "react-native-photo-view": "^1.3.0",

--- a/src/components/comment-list-item.component.js
+++ b/src/components/comment-list-item.component.js
@@ -226,13 +226,6 @@ export class CommentListItem extends Component {
             {defaultRenderer(node.children, parent)}
           </Text>
         );
-      } else if (node.name === 'li' && parent.name === 'ol') {
-        return (
-          <Text key={index} style={textStyle}>
-            {`${Math.ceil((index + 1) / 2)}. `}
-            {defaultRenderer(node.children, parent)}
-          </Text>
-        );
       }
 
       return undefined;
@@ -290,6 +283,7 @@ export class CommentListItem extends Component {
                 value={commentBodyAdjusted()}
                 stylesheet={commentStyles}
                 renderNode={myDomElement}
+                lineBreak={false}
               />}
 
             {comment.body &&

--- a/yarn.lock
+++ b/yarn.lock
@@ -1688,7 +1688,7 @@ dateformat@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-2.0.0.tgz#2743e3abb5c3fc2462e527dca445e04e9f4dee17"
 
-debug@2, debug@2.6.8, debug@^2.1.1, debug@^2.2.0, debug@^2.6.3, debug@^2.6.8:
+debug@2, debug@2.6.8, debug@^2.6.3, debug@^2.6.8:
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
   dependencies:
@@ -4654,9 +4654,9 @@ react-native-elements@^0.9.3:
     react-native-side-menu "^0.20.1"
     react-native-tab-navigator "^0.3.3"
 
-react-native-htmlview@^0.11.1:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/react-native-htmlview/-/react-native-htmlview-0.11.1.tgz#cc8cf18b7076a476e39974ed95270d4850725226"
+react-native-htmlview@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/react-native-htmlview/-/react-native-htmlview-0.12.0.tgz#9b19a7dccd38586c0aebf975e6083184685013a6"
   dependencies:
     entities "^1.1.1"
     htmlparser2-without-node-native "^3.9.0"
@@ -4906,30 +4906,6 @@ read-pkg@^2.0.0:
     load-json-file "^2.0.0"
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
-
-readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.2.6:
-  version "2.2.11"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.11.tgz#0796b31f8d7688007ff0b93a8088d34aa17c0f72"
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "~1.0.0"
-    process-nextick-args "~1.0.6"
-    safe-buffer "~5.0.1"
-    string_decoder "~1.0.0"
-    util-deprecate "~1.0.1"
-
-readable-stream@^2.0.6:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.3"
-    isarray "~1.0.0"
-    process-nextick-args "~1.0.6"
-    safe-buffer "~5.1.1"
-    string_decoder "~1.0.3"
-    util-deprecate "~1.0.1"
 
 readable-stream@1.0.27-1:
   version "1.0.27-1"


### PR DESCRIPTION
In #118 I created an internal quickfix to the `react-native-htmlview` plugin. I also opened an issue in the plugin repo.

As I think it's better to use a global fix than an internal quickfix (:wink:) and as version `0.12` is out and fix this one, we should merge this one.