### PR TITLE
Fix pre-commit lint-staged warning/error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitpoint",
-  "version": "1.1",
+  "version": "1.1.0",
   "private": true,
   "scripts": {
     "start": "react-native start",


### PR DESCRIPTION
`package.json` version was making `linter-staged` failed without any other error/stacktrace than:
```
pre-commit: 
pre-commit: We've failed to pass the specified git pre-commit hooks as the `lint-staged`
pre-commit: hook returned an exit code (1). If you're feeling adventurous you can
pre-commit: skip the git pre-commit hooks by adding the following flags to your commit:
pre-commit: 
pre-commit:   git commit -n (or --no-verify)
pre-commit: 
pre-commit: This is ill-advised since the commit is broken.
pre-commit: 
```

When I added a `.0` to the version number, that allowed me to commit. 

I also tried to update `linter-staged` to 4.0.2 but it didn't fix the pre-commit hooks.

---
I found the error by running:
```
$ npm run lint-staged
npm ERR! Invalid version: "1.1"
npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/antoine/.npm/_logs/2017-07-25T20_56_56_550Z-debug.log
```