### PR TITLE
Feature: Share repository

### DIFF
--- a/src/repository/screens/repository.screen.js
+++ b/src/repository/screens/repository.screen.js
@@ -161,15 +161,13 @@ class Repository extends Component {
     const openIssues = pureIssues.filter(issue => issue.state === 'open');
     const closedIssues = pureIssues.filter(issue => issue.state === 'closed');
 
-    const repositoryActions = [starred ? 'Unstar' : 'Star'];
     const showFork =
       repository && repository.owner && repository.owner.login !== username;
-
-    if (showFork) {
-      repositoryActions.push('Fork');
-    }
-
-    repositoryActions.push('Share');
+    const repositoryActions = [
+      starred ? 'Unstar' : 'Star',
+      showFork && 'Fork',
+      'Share',
+    ];
 
     const loader = isPendingFork ? <LoadingModal /> : null;
 

--- a/src/repository/screens/repository.screen.js
+++ b/src/repository/screens/repository.screen.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { StyleSheet } from 'react-native';
+import { StyleSheet, Share } from 'react-native';
 import { ListItem } from 'react-native-elements';
 import ActionSheet from 'react-native-actionsheet';
 
@@ -99,11 +99,15 @@ class Repository extends Component {
       changeStarStatusRepoByDispatch,
       forkRepoByDispatch,
       navigation,
-      username,
     } = this.props;
-    const showFork = repository.owner.login !== username;
 
     if (index === 0) {
+      // Share
+      this.shareRepository(repository);
+    }
+
+    if (index === 1) {
+      // Star
       changeStarStatusRepoByDispatch(
         repository.owner.login,
         repository.name,
@@ -111,11 +115,28 @@ class Repository extends Component {
       );
     }
 
-    if (index === 1 && showFork) {
+    if (index === 2) {
+      // Fork
       forkRepoByDispatch(repository.owner.login, repository.name).then(json => {
         navigation.navigate('Repository', { repository: json });
       });
     }
+  };
+
+  shareRepository = repository => {
+    const title = `Share ${repository.name}`;
+
+    Share.share(
+      {
+        title,
+        message: `Check out ${repository.name} on Github. ${repository.html_url}`,
+        url: undefined,
+      },
+      {
+        dialogTitle: title,
+        excludedActivityTypes: [],
+      }
+    );
   };
 
   render() {
@@ -145,7 +166,7 @@ class Repository extends Component {
     const openIssues = pureIssues.filter(issue => issue.state === 'open');
     const closedIssues = pureIssues.filter(issue => issue.state === 'closed');
 
-    const repositoryActions = [starred ? '★ Unstar' : '★ Star'];
+    const repositoryActions = ['Share', starred ? 'Unstar' : 'Star'];
     const showFork =
       repository && repository.owner && repository.owner.login !== username;
 
@@ -205,7 +226,8 @@ class Repository extends Component {
               />
             </SectionList>}
 
-          {(isPendingRepository || isPendingContributors) && <LoadingMembersList title="CONTRIBUTORS" />}
+          {(isPendingRepository || isPendingContributors) &&
+            <LoadingMembersList title="CONTRIBUTORS" />}
 
           {!isPendingContributors &&
             <MembersList

--- a/src/repository/screens/repository.screen.js
+++ b/src/repository/screens/repository.screen.js
@@ -99,27 +99,22 @@ class Repository extends Component {
       changeStarStatusRepoByDispatch,
       forkRepoByDispatch,
       navigation,
+      username,
     } = this.props;
+    const showFork = repository.owner.login !== username;
 
     if (index === 0) {
-      // Share
-      this.shareRepository(repository);
-    }
-
-    if (index === 1) {
-      // Star
       changeStarStatusRepoByDispatch(
         repository.owner.login,
         repository.name,
         starred
       );
-    }
-
-    if (index === 2) {
-      // Fork
+    } else if (index === 1 && showFork) {
       forkRepoByDispatch(repository.owner.login, repository.name).then(json => {
         navigation.navigate('Repository', { repository: json });
       });
+    } else if (index === 2 || (index === 1 && !showFork)) {
+      this.shareRepository(repository);
     }
   };
 
@@ -166,13 +161,15 @@ class Repository extends Component {
     const openIssues = pureIssues.filter(issue => issue.state === 'open');
     const closedIssues = pureIssues.filter(issue => issue.state === 'closed');
 
-    const repositoryActions = ['Share', starred ? 'Unstar' : 'Star'];
+    const repositoryActions = [starred ? 'Unstar' : 'Star'];
     const showFork =
       repository && repository.owner && repository.owner.login !== username;
 
     if (showFork) {
       repositoryActions.push('Fork');
     }
+
+    repositoryActions.push('Share');
 
     const loader = isPendingFork ? <LoadingModal /> : null;
 


### PR DESCRIPTION
## Changes
- Added a 'share' action to the actionsheet on the repository screenshot. This uses the native share window, so you have all your available options shown. See the screenshots. (My simulator only has twitter) 
I added the actual repository link to the message, so its visible to the user that it also shares the url. If the `url` key is used in the share method it doesn't show the url. I thought that it might be strange for the user. 
- Removed unicode star. Since we don't have the octicons in the actionsheet yet, i removed the star since it doesn't look good otherwise.

## Screenshots
![Share-screen1](http://preview.ibb.co/e3oHEk/Screen_Shot_2017_07_26_at_23_52_57.png)
![Share-screen2](http://preview.ibb.co/eX7Yn5/Screen_Shot_2017_07_26_at_23_53_20.png)
![Share-screen3](http://preview.ibb.co/jMhNfQ/Screen_Shot_2017_07_26_at_23_53_26.png)
