### PR TITLE
Set correct issue titles

### DIFF
--- a/src/auth/screens/events.screen.js
+++ b/src/auth/screens/events.screen.js
@@ -424,19 +424,22 @@ class Events extends Component {
           }
         : userEvent.payload.forkee,
     });
-  }
+  };
 
   navigateToIssue = userEvent => {
     this.props.navigation.navigate('Issue', {
-      issue: userEvent.payload.issue || this.formatPullRequestObject(userEvent.payload.pull_request),
+      issue:
+        userEvent.payload.issue ||
+        this.formatPullRequestObject(userEvent.payload.pull_request),
+      isPR: !!userEvent.payload.pull_request,
     });
-  }
+  };
 
   navigateToProfile = (userEvent, isActor) => {
     this.props.navigation.navigate('Profile', {
       user: !isActor ? userEvent.payload.member : userEvent.actor,
     });
-  }
+  };
 
   keyExtractor = item => {
     return item.id;

--- a/src/components/issue-list-item.component.js
+++ b/src/components/issue-list-item.component.js
@@ -46,6 +46,7 @@ export const IssueListItem = ({ type, issue, navigation }: Props) =>
     onPress={() =>
       navigation.navigate('Issue', {
         issue,
+        isPR: !!issue.pull_request,
       })}
     underlayColor={colors.greyLight}
   >


### PR DESCRIPTION
Earlier in #160 this was fixed for the notification screen, the current PR sets the correct titles for all other (events and issue list component).