### PR TITLE
Hide tabbar when scrolling down on events screen

### DIFF
--- a/routes.js
+++ b/routes.js
@@ -1,14 +1,11 @@
 /* eslint-disable react/prop-types */
 import React from 'react';
-import {
-  StackNavigator,
-  TabNavigator,
-  TabBarBottom,
-  NavigationActions,
-} from 'react-navigation';
+import { StackNavigator, TabNavigator } from 'react-navigation';
 import { Icon } from 'react-native-elements';
 
 import { colors } from 'config';
+
+import { TabBar } from 'components';
 
 // Auth
 import {
@@ -294,33 +291,7 @@ const MainTabNavigator = TabNavigator(
       activeTintColor: colors.primaryDark,
       inactiveTintColor: colors.grey,
     },
-    tabBarComponent: ({ jumpToIndex, ...props }) =>
-      <TabBarBottom
-        {...props}
-        jumpToIndex={index => {
-          const { dispatch, state } = props.navigation;
-
-          if (state.index === index && state.routes[index].routes.length > 1) {
-            const stackRouteName = [
-              'Events',
-              'Notifications',
-              'Search',
-              'MyProfile',
-            ][index];
-
-            dispatch(
-              NavigationActions.reset({
-                index: 0,
-                actions: [
-                  NavigationActions.navigate({ routeName: stackRouteName }),
-                ],
-              })
-            );
-          } else {
-            jumpToIndex(index);
-          }
-        }}
-      />,
+    tabBarComponent: TabBar,
   }
 );
 

--- a/src/auth/auth.action.js
+++ b/src/auth/auth.action.js
@@ -18,6 +18,7 @@ import {
   GET_AUTH_ORGS,
   GET_EVENTS,
   CHANGE_LANGUAGE,
+  CHANGE_TAB_BAR_VISIBILITY,
 } from './auth.type';
 
 export const auth = (code, state, navigation) => {
@@ -139,5 +140,11 @@ export const changeLanguage = lang => {
   return dispatch => {
     dispatch({ type: CHANGE_LANGUAGE.SUCCESS, payload: lang });
     I18n.locale = lang;
+  };
+};
+
+export const changeTabBarVisibility = isTabBarVisible => {
+  return dispatch => {
+    dispatch({ type: CHANGE_TAB_BAR_VISIBILITY, isTabBarVisible });
   };
 };

--- a/src/auth/auth.reducer.js
+++ b/src/auth/auth.reducer.js
@@ -6,6 +6,7 @@ import {
   GET_AUTH_ORGS,
   GET_EVENTS,
   CHANGE_LANGUAGE,
+  CHANGE_TAB_BAR_VISIBILITY,
 } from './auth.type';
 
 const initialState = {
@@ -22,6 +23,7 @@ const initialState = {
   isPendingOrgs: false,
   isPendingEvents: false,
   error: '',
+  isTabBarVisible: true,
 };
 
 export const authReducer = (state = initialState, action = {}) => {
@@ -118,6 +120,11 @@ export const authReducer = (state = initialState, action = {}) => {
       return {
         ...state,
         language: action.payload,
+      };
+    case CHANGE_TAB_BAR_VISIBILITY:
+      return {
+        ...state,
+        isTabBarVisible: action.isTabBarVisible,
       };
     default:
       return state;

--- a/src/auth/auth.type.js
+++ b/src/auth/auth.type.js
@@ -6,3 +6,4 @@ export const GET_AUTH_USER = createActionSet('GET_AUTH_USER');
 export const GET_AUTH_ORGS = createActionSet('GET_AUTH_ORGS');
 export const GET_EVENTS = createActionSet('GET_EVENTS');
 export const CHANGE_LANGUAGE = createActionSet('CHANGE_LANGUAGE');
+export const CHANGE_TAB_BAR_VISIBILITY = 'CHANGE_TAB_BAR_VISIBILITY';

--- a/src/auth/screens/events.screen.js
+++ b/src/auth/screens/events.screen.js
@@ -8,7 +8,7 @@ import moment from 'moment';
 import { LoadingUserListItem, UserListItem, ViewContainer } from 'components';
 import { colors, fonts, normalize } from 'config';
 import { emojifyText, translate } from 'utils';
-import { getUserEvents } from '../auth.action';
+import { getUserEvents, changeTabBarVisibility } from '../auth.action';
 
 moment.updateLocale('en', {
   relativeTime: {
@@ -32,10 +32,13 @@ const mapStateToProps = state => ({
   userEvents: state.auth.events,
   language: state.auth.language,
   isPendingEvents: state.auth.isPendingEvents,
+  isTabBarVisible: state.auth.isTabBarVisible,
 });
 
 const mapDispatchToProps = dispatch => ({
   getUserEvents: user => dispatch(getUserEvents(user)),
+  changeTabBarVisibility: isTabBarVisible =>
+    dispatch(changeTabBarVisibility(isTabBarVisible)),
 });
 
 const styles = StyleSheet.create({
@@ -85,6 +88,13 @@ const styles = StyleSheet.create({
 });
 
 class Events extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      scrollOffset: 0,
+    };
+  }
+
   componentDidMount() {
     if (this.props.user.login) {
       this.getUserEvents(this.props.user);
@@ -475,6 +485,17 @@ class Events extends Component {
     return item.id;
   };
 
+  changeTabBarVisibility = event => {
+    const scrollOffset = event.nativeEvent.contentOffset.y;
+    const isScrollDown = scrollOffset > this.state.scrollOffset;
+
+    this.setState({
+      scrollOffset,
+    });
+
+    this.props.changeTabBarVisibility(!isScrollDown);
+  };
+
   renderDescription(userEvent) {
     return (
       <Text style={styles.descriptionContainer}>
@@ -526,6 +547,8 @@ class Events extends Component {
           onRefresh={this.getUserEvents}
           refreshing={isPendingEvents}
           keyExtractor={this.keyExtractor}
+          onScroll={this.changeTabBarVisibility}
+          onEndReachedThreshold={1200}
           renderItem={({ item }) =>
             <View>
               <UserListItem

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -23,3 +23,4 @@ export * from './user-list-item.component';
 export * from './user-profile.component';
 export * from './view-container.component';
 export * from './image-zoom.component';
+export * from './tab-bar.component';

--- a/src/components/tab-bar.component.js
+++ b/src/components/tab-bar.component.js
@@ -1,0 +1,113 @@
+/* eslint-disable no-unused-expressions */
+
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { Animated, LayoutAnimation } from 'react-native';
+import { TabBarBottom, NavigationActions } from 'react-navigation';
+
+import { animations } from 'config';
+
+const mapStateToProps = state => {
+  return {
+    isTabBarVisible: state.auth.isTabBarVisible,
+  };
+};
+
+class TabBarComponent extends Component {
+  props: {
+    isTabBarVisible: boolean,
+    navigation: Object,
+    jumpToIndex: Function,
+  };
+
+  state: {
+    animatedHeight: Animated,
+    expandedHeight: number,
+  };
+
+  constructor() {
+    super();
+    this.state = {
+      animatedHeight: new Animated.Value(),
+      expandedHeight: '',
+    };
+  }
+
+  componentWillReceiveProps(nextState) {
+    if (nextState.isTabBarVisible !== this.props.isTabBarVisible) {
+      nextState.isTabBarVisible ? this.show() : this.hide();
+    }
+  }
+
+  setExpandedHeight(event) {
+    if (!this.state.expandedHeight) {
+      const expandedHeight = event.nativeEvent.layout.height;
+
+      this.state = {
+        animatedHeight: new Animated.Value(expandedHeight),
+        expandedHeight,
+      };
+    }
+  }
+
+  changeHeight(from, to) {
+    LayoutAnimation.configureNext(LayoutAnimation.Presets.spring);
+
+    this.state.animatedHeight.setValue(from);
+
+    Animated.spring(this.state.animatedHeight, {
+      toValue: to,
+      duration: animations.duration,
+      friction: animations.friction,
+    }).start();
+  }
+
+  show() {
+    this.changeHeight(0, this.state.expandedHeight);
+  }
+
+  hide() {
+    this.changeHeight(this.state.expandedHeight, 0);
+  }
+
+  render() {
+    return (
+      <Animated.View
+        style={{ height: this.state.animatedHeight }}
+        onLayout={event => this.setExpandedHeight(event)}
+      >
+        <TabBarBottom
+          {...this.props}
+          jumpToIndex={index => {
+            const { dispatch, state } = this.props.navigation;
+
+            if (
+              state.index === index &&
+              state.routes[index].routes.length > 1
+            ) {
+              const stackRouteName = [
+                'Events',
+                'Notifications',
+                'Search',
+                'MyProfile',
+              ][index];
+
+              dispatch(
+                NavigationActions.reset({
+                  index: 0,
+                  actions: [
+                    NavigationActions.navigate({ routeName: stackRouteName }),
+                  ],
+                })
+              );
+            } else {
+              this.props.jumpToIndex(index);
+            }
+          }}
+        />
+      </Animated.View>
+    );
+  }
+}
+
+export const TabBar = connect(mapStateToProps)(TabBarComponent);


### PR DESCRIPTION
Sorry, could not make the gif, so did a [demo video](https://files.gitter.im/git-point/Lobby/QBGj/demo1.mp4). The idea was to hide the tabbar when scrolling down on the events screen. When scrolling back up, it is shown again.

With animation there are problems, it is not so smooth now. Maybe someone knows why? Also need to check at it on iOS. I will be grateful for any help, thank you!