### PR TITLE
Navigate to auth profile screen for the current user

### DIFF
--- a/routes.js
+++ b/routes.js
@@ -82,6 +82,12 @@ const sharedRoutes = {
       header: null,
     },
   },
+  AuthProfile: {
+    screen: AuthProfileScreen,
+    navigationOptions: {
+      header: null,
+    },
+  },
   Organization: {
     screen: OrganizationProfileScreen,
     navigationOptions: {

--- a/src/components/comment-list-item.component.js
+++ b/src/components/comment-list-item.component.js
@@ -2,6 +2,7 @@
 /* eslint-disable no-nested-ternary */
 
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import {
   StyleSheet,
   View,
@@ -118,16 +119,21 @@ const commentStyles = StyleSheet.create({
   a: linkStyle,
 });
 
-export class CommentListItem extends Component {
+const mapStateToProps = state => ({
+  authUser: state.auth.user,
+});
+
+class CommentListItemComponent extends Component {
   props: {
     comment: Object,
     onLinkPress: Function,
     language: string,
     navigation: Object,
+    authUser: Object,
   };
 
   render() {
-    const { comment, language, navigation } = this.props;
+    const { comment, language, navigation, authUser } = this.props;
     const commentBodyAdjusted = () =>
       comment.body_html
         .replace(new RegExp(/<img[^>]*>/g), 'Image')
@@ -244,9 +250,14 @@ export class CommentListItem extends Component {
             <TouchableOpacity
               style={styles.avatarContainer}
               onPress={() =>
-                navigation.navigate('Profile', {
-                  user: comment.user,
-                })}
+                navigation.navigate(
+                  authUser.login === comment.user.login
+                    ? 'AuthProfile'
+                    : 'Profile',
+                  {
+                    user: comment.user,
+                  }
+                )}
             >
               <Image
                 style={styles.avatar}
@@ -260,9 +271,14 @@ export class CommentListItem extends Component {
             <TouchableOpacity
               style={styles.titleSubtitleContainer}
               onPress={() =>
-                navigation.navigate('Profile', {
-                  user: comment.user,
-                })}
+                navigation.navigate(
+                  authUser.login === comment.user.login
+                    ? 'AuthProfile'
+                    : 'Profile',
+                  {
+                    user: comment.user,
+                  }
+                )}
             >
               <Text style={styles.linkDescription}>
                 {comment.user.login}
@@ -320,3 +336,7 @@ export class CommentListItem extends Component {
     );
   }
 }
+
+export const CommentListItem = connect(mapStateToProps)(
+  CommentListItemComponent
+);

--- a/src/components/members.component.js
+++ b/src/components/members.component.js
@@ -1,5 +1,5 @@
 import React from 'react';
-
+import { connect } from 'react-redux';
 import {
   StyleSheet,
   View,
@@ -11,12 +11,17 @@ import {
 
 import { colors, fonts } from 'config';
 
+const mapStateToProps = state => ({
+  authUser: state.auth.user,
+});
+
 type Props = {
   title: string,
   members: Array,
   containerStyle: Object,
   smallTitle: string,
   navigation: Object,
+  authUser: Object,
 };
 
 const styles = StyleSheet.create({
@@ -48,12 +53,13 @@ const styles = StyleSheet.create({
   },
 });
 
-export const MembersList = ({
+const MembersListComponent = ({
   title,
   members,
   containerStyle,
   smallTitle,
   navigation,
+  authUser,
 }: Props) =>
   <View style={[styles.container, containerStyle && containerStyle]}>
     <Text style={smallTitle ? styles.sectionTitleSmall : styles.sectionTitle}>
@@ -65,10 +71,14 @@ export const MembersList = ({
       showsHorizontalScrollIndicator={false}
       renderItem={({ item }) =>
         <TouchableHighlight
-          onPress={() =>
-            navigation.navigate('Profile', {
-              user: item,
-            })}
+          onPress={() => {
+            navigation.navigate(
+              authUser.login === item.login ? 'AuthProfile' : 'Profile',
+              {
+                user: item,
+              }
+            );
+          }}
           underlayColor="transparent"
           style={styles.avatarContainer}
         >
@@ -83,3 +93,5 @@ export const MembersList = ({
       horizontal
     />
   </View>;
+
+export const MembersList = connect(mapStateToProps)(MembersListComponent);

--- a/src/issue/screens/issue.screen.js
+++ b/src/issue/screens/issue.screen.js
@@ -84,7 +84,7 @@ class Issue extends Component {
     diff: string,
     issue: Object,
     isMerged: boolean,
-    // authUser: Object,
+    authUser: Object,
     repository: Object,
     contributors: Array,
     comments: Array,
@@ -103,12 +103,17 @@ class Issue extends Component {
   }
 
   onLinkPress = node => {
-    const { navigation } = this.props;
+    const { navigation, authUser } = this.props;
 
     if (node.attribs.class && node.attribs.class.includes('user-mention')) {
-      navigation.navigate('Profile', {
-        user: { login: node.children[0].data.substring(1) },
-      });
+      const login = node.children[0].data.substring(1);
+
+      navigation.navigate(
+        authUser.login === login ? 'AuthProfile' : 'Profile',
+        {
+          user: { login },
+        }
+      );
     } else if (
       node.attribs.class &&
       node.attribs.class.includes('issue-link')


### PR DESCRIPTION
Now the screen auth profile can only be when navigating from the tabbar, although it is displayed for the current user from other places: if the user is on the organization list, if it is mentioned in the issue description or in its comments. Of all these places user should be navigated **not** to the normal profile screen, but to the auth profile.

From this follows such a problem that I can _follow myself_ (:rofl:), or again, organizations will not all be displayed.
