### PR TITLE
fix(repo): Show repo prefix for search repo result

### DIFF
--- a/src/components/repository-list-item.component.js
+++ b/src/components/repository-list-item.component.js
@@ -62,7 +62,7 @@ const renderTitle = repository =>
     <View style={styles.repositoryContainer}>
       <View style={styles.titleWrapper}>
         <Text style={styles.title}>
-          {repository.name}
+          {repository.full_name}
         </Text>
         {repository.private && <Text style={styles.private}>Private</Text>}
       </View>


### PR DESCRIPTION
Closes #252 

- [x] show repo prefix

# Preview

![image](https://user-images.githubusercontent.com/5353857/29321429-9ab715f6-8204-11e7-86cf-3fd025665833.png)
