### PR TITLE
refactor(onboarding-swiper): replace component

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "react-native-photo-view": "^1.4.0",
     "react-native-safari-view": "^2.0.0",
     "react-native-search-bar": "^3.0.0",
-    "react-native-swiper": "^1.5.4",
+    "react-native-app-intro": "^1.1.5",
     "react-native-syntax-highlighter": "^1.2.1",
     "react-native-vector-icons": "^4.0.0",
     "react-navigation": "^1.0.0-beta.11",

--- a/src/auth/screens/login.screen.js
+++ b/src/auth/screens/login.screen.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { Linking, View, StyleSheet, Text, Platform, Image } from 'react-native';
 import { Button, Icon } from 'react-native-elements';
 import SafariView from 'react-native-safari-view';
-import Swiper from 'react-native-swiper';
+import AppIntro from 'react-native-app-intro';
 import queryString from 'query-string';
 
 import { ViewContainer, LoadingContainer } from 'components';
@@ -172,7 +172,11 @@ class Login extends Component {
             </View>
 
             <View style={styles.contentSection}>
-              <Swiper activeDotColor={colors.white}>
+              <AppIntro
+                activeDotColor={colors.white}
+                showSkipButton={false}
+                showDoneButton={false}
+              >
                 <View style={[styles.slide, styles.slide1]}>
                   <Image
                     style={styles.logo}
@@ -235,7 +239,7 @@ class Login extends Component {
                     {translate('auth.login.issuesMessage', language)}
                   </Text>
                 </View>
-              </Swiper>
+              </AppIntro>
             </View>
 
             <View style={styles.miniSection}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -314,6 +314,18 @@ assert-plus@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-0.2.0.tgz#d74e1b87e7affc0db8aadb7021f3fe48101ab234"
 
+assign-deep@^0.4.5:
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/assign-deep/-/assign-deep-0.4.6.tgz#2192a989354843093a03eff941c9473a9bc58a1d"
+  dependencies:
+    assign-symbols "^0.1.1"
+    is-primitive "^2.0.0"
+    kind-of "^5.0.2"
+
+assign-symbols@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-0.1.1.tgz#cb025944ef4ec8a3693f086e9e112c74e3a0fed9"
+
 ast-types-flow@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
@@ -3834,6 +3846,10 @@ kind-of@^4.0.0:
   dependencies:
     is-buffer "^1.1.5"
 
+kind-of@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-5.0.2.tgz#f57bec933d9a2209ffa96c5c08343607b7035fda"
+
 klaw@^1.0.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/klaw/-/klaw-1.3.1.tgz#4088433b46b3b1ba259d78785d8e96f73ba02439"
@@ -5095,6 +5111,13 @@ react-native-actionsheet@^2.2.0:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/react-native-actionsheet/-/react-native-actionsheet-2.2.2.tgz#469075a7d1c8e5b5d0829294bf9a2c4d2eb7e34e"
 
+react-native-app-intro@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/react-native-app-intro/-/react-native-app-intro-1.1.5.tgz#34a2d2265b2d654d31bae743c404856c37448692"
+  dependencies:
+    assign-deep "^0.4.5"
+    react-native-swiper "git+https://github.com/FuYaoDe/react-native-swiper.git"
+
 react-native-cli@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/react-native-cli/-/react-native-cli-2.0.1.tgz#f2cd3c7aa1b83828cdfba630e2dfd817df766d54"
@@ -5189,11 +5212,11 @@ react-native-side-menu@^0.20.1:
   version "0.20.3"
   resolved "https://registry.yarnpkg.com/react-native-side-menu/-/react-native-side-menu-0.20.3.tgz#5dffe3e237018360ed081433d505ea454cba9ca4"
 
-react-native-swiper@^1.5.4:
-  version "1.5.9"
-  resolved "https://registry.yarnpkg.com/react-native-swiper/-/react-native-swiper-1.5.9.tgz#7f7cd21e74a0c9fe7ac25c12714bf4d655823920"
+"react-native-swiper@git+https://github.com/FuYaoDe/react-native-swiper.git":
+  version "1.4.4"
+  resolved "git+https://github.com/FuYaoDe/react-native-swiper.git#a6417ff41a8b2d490bdcc4541015ab35736d4595"
   dependencies:
-    prop-types "^15.5.10"
+    react-timer-mixin "^0.13.3"
 
 react-native-syntax-highlighter@^1.2.1:
   version "1.2.3"
@@ -5359,7 +5382,7 @@ react-test-renderer@16.0.0-alpha.6:
     fbjs "^0.8.9"
     object-assign "^4.1.0"
 
-react-timer-mixin@^0.13.2:
+react-timer-mixin@^0.13.2, react-timer-mixin@^0.13.3:
   version "0.13.3"
   resolved "https://registry.yarnpkg.com/react-timer-mixin/-/react-timer-mixin-0.13.3.tgz#0da8b9f807ec07dc3e854d082c737c65605b3d22"
 


### PR DESCRIPTION
Unfortunately after updating React Native to 0.47.1 in PR #208, stopped working `onboarding swiper` (#174). I noticed this just now, because I left from  the GitHub account. And since the application has not been updated in the App Store/Google Play for a month, then this problem has not been detected, so we need to update the application _more often_ to detect such problems as quickly as possible.

On Android does not applies the background color (screenshot below), issue was [created](https://github.com/leecade/react-native-swiper/issues/511), but so far it has not been fixed and it is not known when it will be fixed. 

<img src="https://user-images.githubusercontent.com/4408379/30102933-c975c0bc-92f9-11e7-9f29-b2653d9e413c.png"  width="300"  />

Therefore, I propose to replace the `react-native-swiper` component with the `react-native-app-intro`. All looks also, except for the sizes of dots, they are a little more, but in fact it is not the big problem?

<img src="https://user-images.githubusercontent.com/4408379/30102938-cd0e8b1e-92f9-11e7-8c53-c8dd5cc2f578.png"  width="300"  />
