### PR TITLE
refactor(abbreviate numbers): improve algorithm, use localization

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,3 +1,5 @@
+import { abbreviateNumber } from 'utils';
+
 // These keys are for development purposes and do not represent the actual application keys.
 // Feel free to use them or use a new set of keys by creating an OAuth application of your own.
 // https://github.com/settings/applications/new
@@ -326,16 +328,7 @@ export async function fetchStarCount(owner) {
     output = linkHeader.split('=').pop();
   }
 
-  // Add 'k' if star more than 1000
-
-  if (output > 1000) {
-    const outDecimal = (output / 1000).toString();
-    const dotIndex = outDecimal.indexOf('.');
-
-    output = `${outDecimal.substring(0, dotIndex + 3)}k`;
-  }
-
-  return output;
+  return abbreviateNumber(output);
 }
 
 export async function watchRepo(isSubscribed, owner, repo, accessToken) {

--- a/src/locale/languages/en.js
+++ b/src/locale/languages/en.js
@@ -317,5 +317,8 @@ export const en = {
       y: '%dy',
       yy: '%dy',
     },
+    abbreviations: {
+      thousand: 'k',
+    },
   },
 };

--- a/src/locale/languages/fr.js
+++ b/src/locale/languages/fr.js
@@ -317,5 +317,8 @@ export const fr = {
       y: '%da',
       yy: '%da',
     },
+    abbreviations: {
+      thousand: 'k',
+    },
   },
 };

--- a/src/locale/languages/nl.js
+++ b/src/locale/languages/nl.js
@@ -313,5 +313,8 @@ export const nl = {
       y: '%dy',
       yy: '%dy',
     },
+    abbreviations: {
+      thousand: 'k',
+    },
   },
 };

--- a/src/locale/languages/tr.js
+++ b/src/locale/languages/tr.js
@@ -1,31 +1,32 @@
 export const tr = {
   auth: {
     login: {
-      welcomeTitle: 'GitPoint\'e Hoşgeldiniz',
-      welcomeMessage: 'En zengin özelliklere sahip GitHub client\'ı ve 100% ücretsiz',
+      welcomeTitle: "GitPoint'e Hoşgeldiniz",
+      welcomeMessage:
+        "En zengin özelliklere sahip GitHub client'ı ve 100% ücretsiz",
       notificationsTitle: 'Bildirimleri Kontrol Et',
       notificationsMessage:
         'Okunmamış ve katılımcı olduğunuz bildirimlerinizin tümünü görüntüleyin ve kontrol edin',
-      reposTitle: 'Repository\'ler ve Kullanıcılar',
+      reposTitle: "Repository'ler ve Kullanıcılar",
       reposMessage:
-        'Repository\'leri, kullanıcıları ve organizasyon bilgilerini kolayca edinin',
-      issuesTitle: 'Issue\'lar ve Pull Request\'ler',
+        "Repository'leri, kullanıcıları ve organizasyon bilgilerini kolayca edinin",
+      issuesTitle: "Issue'lar ve Pull Request'ler",
       issuesMessage:
-        'Sohbet ederek iletişim kurun, pull request\'leri merge edin ve daha fazlası',
+        "Sohbet ederek iletişim kurun, pull request'leri merge edin ve daha fazlası",
       signInButton: 'GİRİŞ YAP',
     },
     welcome: {
-      welcomeTitle: 'GitPoint\'e Hoşgeldiniz',
+      welcomeTitle: "GitPoint'e Hoşgeldiniz",
     },
     events: {
       welcomeMessage:
-        'Hoşgeldiniz! Bu, haber kaynağınızdır - izlediğiniz repository\'lerde ve takip ettiğiniz kişilerle ilgili son etkinlikleri takip etmenize yardımcı olur.',
-      commitCommentEvent: 'commit\'e yorum yapıldı',
+        "Hoşgeldiniz! Bu, haber kaynağınızdır - izlediğiniz repository'lerde ve takip ettiğiniz kişilerle ilgili son etkinlikleri takip etmenize yardımcı olur.",
+      commitCommentEvent: "commit'e yorum yapıldı",
       createEvent: '{{object}} oluşturuldu',
       deleteEvent: '{{object}} silindi',
       issueCommentEvent: '{{type}} {{action}}',
-      issueEditedEvent: '{{type}}\'daki yorum {{action}}',
-      issueRemovedEvent: '{{type}}\'den yorum {{action}}',
+      issueEditedEvent: "{{type}}'daki yorum {{action}}",
+      issueRemovedEvent: "{{type}}'den yorum {{action}}",
       issuesEvent: '{{action}} issue',
       publicEvent: {
         action: 'made',
@@ -33,9 +34,9 @@ export const tr = {
       },
       pullRequestEvent: 'pull request {{action}}',
       pullRequestReviewEvent: 'pull request incelemesi {{action}}',
-      pullRequestReviewCommentEvent: 'pull request\'e {{action}}',
-      pullRequestReviewEditedEvent: 'pull request\'deki yorum {{action}}',
-      pullRequestReviewDeletedEvent: 'pull request\'deki yorum {{action}}',
+      pullRequestReviewCommentEvent: "pull request'e {{action}}",
+      pullRequestReviewEditedEvent: "pull request'deki yorum {{action}}",
+      pullRequestReviewDeletedEvent: "pull request'deki yorum {{action}}",
       releaseEvent: 'release {{action}}',
       atConnector: 'de',
       toConnector: 'dan',
@@ -70,7 +71,7 @@ export const tr = {
         publicized: 'Halka açıldı',
         privatized: 'Özel yapıldı',
         starred: 'yıldızlı',
-        pushedTo: '\'a push edildi',
+        pushedTo: "'a push edildi",
         forked: 'fork edildi',
         commented: 'yorum yaptı',
         removed: 'silindi',
@@ -95,7 +96,7 @@ export const tr = {
       title: 'Gizlilik Politikası',
       effectiveDate: 'Son Güncelleme: Temmuz 15, 2017',
       introduction:
-        'GitPoint\'i kullanmaya karar verdiğiniz için mutluyuz. Bu Gizlilik Politikası, burada kullanıcılarımızın verileri ile ne yapıp ne yapmadığımızı size bildirmek için hazırlanmıştır.',
+        "GitPoint'i kullanmaya karar verdiğiniz için mutluyuz. Bu Gizlilik Politikası, burada kullanıcılarımızın verileri ile ne yapıp ne yapmadığımızı size bildirmek için hazırlanmıştır.",
       userDataTitle: 'KULLANICI VERİSİ',
       userData1:
         'GitHub bilgilerinizle hiçbir şey yapmıyoruz. Kimlik doğrulamasından sonra, kullanıcının OAuth belirteci doğrudan kendi cihaz depolama biriminde kalır. Bu bilgileri geri almamız mümkün değildir. Bir kullanıcının erişim simgesini hiçbir zaman görüntülemiyoruz ve ne olursa olsun saklamıyoruz.',
@@ -103,7 +104,7 @@ export const tr = {
         'Bu, bir kullanıcının GitHub verilerini hiçbir şekilde görüntüleyemememiz, kullanmamamız veya paylaşmamamız anlamına gelir. Özel veriler, herhangi bir noktada görünür hale gelirse, kaydetmeyeceğiz veya görüntülemeyeceğiz. Yanlışlıkla kaydedilmişse, güvenli silme yöntemlerini kullanarak derhal silecektir. Yine, kimlik doğrulamasını özel olarak bu şekilde asla gerçekleşmeyecek şekilde kurduk.',
       analyticsInfoTitle: 'ANALİTİK BİLGİLER',
       analyticsInfo1:
-        'Şu anda, GitPoint için trafik ve kullanım bilgilerini ölçmemize yardımcı olması için Google Analytics\'i ve iTunes App Analytics\'i kullanıyoruz. Bu araçlar, aygıt ve platform sürümü, bölge ve yönlendiren de dahil olmak üzere aygıtınız tarafından gönderilen bilgileri toplar. Bu bilgi belirli bir kullanıcıyı tanımlamak için makul bir şekilde kullanılamaz ve hiçbir kişisel bilgi çıkarılamaz.',
+        "Şu anda, GitPoint için trafik ve kullanım bilgilerini ölçmemize yardımcı olması için Google Analytics'i ve iTunes App Analytics'i kullanıyoruz. Bu araçlar, aygıt ve platform sürümü, bölge ve yönlendiren de dahil olmak üzere aygıtınız tarafından gönderilen bilgileri toplar. Bu bilgi belirli bir kullanıcıyı tanımlamak için makul bir şekilde kullanılamaz ve hiçbir kişisel bilgi çıkarılamaz.",
       analyticsInfo2:
         'Yığın izlerini, hata günlüklerini veya daha fazla analitik bilgi toplamak için başka bir üçüncü taraf platformu eklersek, kullanıcı verilerinin anonim ve şifrelenip korunup korunmadığından emin oluruz.',
       openSourceTitle: 'AÇIK KAYNAK',
@@ -113,10 +114,10 @@ export const tr = {
         'Uygulamaya yapılan her katkı ile kod incelemesi, her zaman herkese, her türlü kötü niyetli kodu eklemez.',
       contactTitle: 'İLETİŞİM',
       contact1:
-        'Gizlilik Politikamızı okuduğunuz için teşekkür ederiz. Umarız gitPoint\'i keyifle kullandığımız kadar beğenirsiniz.',
+        "Gizlilik Politikamızı okuduğunuz için teşekkür ederiz. Umarız gitPoint'i keyifle kullandığımız kadar beğenirsiniz.",
       contact2:
         'Genel olarak bu Gizlilik Politikası veya GitPoint ile ilgili herhangi bir sorunuz varsa lütfen;',
-      contactLink: 'GitPoint repository\'si',
+      contactLink: "GitPoint repository'si",
     },
   },
   notifications: {
@@ -133,7 +134,7 @@ export const tr = {
   },
   search: {
     main: {
-      repositoryButton: 'Repository\'ler',
+      repositoryButton: "Repository'ler",
       userButton: 'Kullanıcılar',
       searchingMessage: '{{query}} aranıyor',
       searchMessage: 'Herhangi bir {{type}} ara',
@@ -148,7 +149,7 @@ export const tr = {
       follow: 'Takip et',
     },
     repositoryList: {
-      title: 'Repository\'ler',
+      title: "Repository'ler",
     },
     followerList: {
       title: 'Takipçiler',
@@ -163,7 +164,8 @@ export const tr = {
   repository: {
     main: {
       shareRepositoryTitle: 'Paylaş {{repoName}}',
-      shareRepositoryMessage: 'GitHub\'daki {{repoName}}\'i kontrol edin. {{repoUrl}}',
+      shareRepositoryMessage:
+        "GitHub'daki {{repoName}}'i kontrol edin. {{repoUrl}}",
       repoActions: 'Repository Hareketleri',
       forkAction: 'Fork',
       starAction: 'Star',
@@ -177,14 +179,14 @@ export const tr = {
       sourceTitle: 'KAYNAK',
       readMe: 'BENİ OKU',
       viewSource: 'View Code',
-      issuesTitle: 'ISSUE\'LER',
+      issuesTitle: "ISSUE'LER",
       noIssuesMessage: 'issue yok',
       noOpenIssuesMessage: 'Açık issue yok',
       viewAllButton: 'Tümünü Göster',
       newIssueButton: 'Yeni Issue',
-      pullRequestTitle: 'PULL REQUEST\'LER',
+      pullRequestTitle: "PULL REQUEST'LER",
       noPullRequestsMessage: 'Pull request Yok',
-      noOpenPullRequestsMessage: 'Açık pull request\'ler',
+      noOpenPullRequestsMessage: "Açık pull request'ler",
       starsTitle: 'Stars',
       forksTitle: 'Forks',
       forkedFromMessage: 'buradan fork edildi:',
@@ -195,7 +197,7 @@ export const tr = {
       title: 'Code',
     },
     issueList: {
-      title: 'Issue\'ler',
+      title: "Issue'ler",
       openButton: 'Açık',
       closedButton: 'Kapalı',
       searchingMessage: '{{query}} aranıyor',
@@ -203,7 +205,7 @@ export const tr = {
       noClosedIssues: 'Kapalı issue bulunamadı!',
     },
     pullList: {
-      title: 'Pull Request\'ler',
+      title: "Pull Request'ler",
       openButton: 'Açık',
       closedButton: 'Kapalı',
       searchingMessage: '{{query}} aranıyor',
@@ -215,7 +217,8 @@ export const tr = {
       numFilesChanged: '{{numFilesChanged}} dosya',
       new: 'YENİ',
       deleted: 'SİLİNDİ',
-      fileRenamed: 'Dosya herhangi bir değişiklik yapılmaksızın yeniden adlandırıldı',
+      fileRenamed:
+        'Dosya herhangi bir değişiklik yapılmaksızın yeniden adlandırıldı',
     },
   },
   organization: {
@@ -240,7 +243,7 @@ export const tr = {
       closeIssue: 'Kapat {{issueType}}',
       reopenIssue: 'Yeniden aç {{issueType}}',
       areYouSurePrompt: 'Emin misiniz?',
-      applyLabelTitle: 'Bu issue\'ya bir etiket uygulayın',
+      applyLabelTitle: "Bu issue'ya bir etiket uygulayın",
     },
     main: {
       assignees: 'Atananlar',
@@ -293,7 +296,7 @@ export const tr = {
     location: 'Konum',
     email: 'Email',
     website: 'Website',
-    repositories: 'Repository\'ler',
+    repositories: "Repository'ler",
     followers: 'Takipçiler',
     following: 'Takip',
     cancel: 'Vazgeç',
@@ -313,6 +316,9 @@ export const tr = {
       MM: '%dmo',
       y: '%dy',
       yy: '%dy',
+    },
+    abbreviations: {
+      thousand: 'k',
     },
   },
 };

--- a/src/utils/text-helper.js
+++ b/src/utils/text-helper.js
@@ -1,11 +1,20 @@
 import emoji from 'node-emoji';
+import I18n from 'locale';
 
-const thousandUnit = 'k';
+import { translate } from 'utils';
 
 export const emojifyText = text => {
   return emoji.emojify(text);
 };
 
 export const abbreviateNumber = count => {
-  return count >= 1000 ? (count / 1000).toFixed(1) + thousandUnit : count;
+  const thousandUnit = translate('common.abbreviations.thousand', I18n.locale);
+
+  if (count > 999) {
+    return count % 1000 < 50
+      ? (count / 1000).toFixed(0) + thousandUnit
+      : (count / 1000).toFixed(1) + thousandUnit;
+  }
+
+  return count;
 };


### PR DESCRIPTION
First, now one digit after the decimal point is shown (instead of `1.33k` there will be `1.3k`, as on GitHub). And also improved the formatting algorithm, which excludes the output of zero after the comma (for example, earlier for the number 1005 was formatted as `1.0k`, now it will be just `1k`).
Secondly, localization is added.
And last, when fetching stars, this `abbreviateNumber` method is used.