### PR TITLE
fix(repository): Fix the wrong watch count

### DIFF
--- a/src/components/repository-profile.component.js
+++ b/src/components/repository-profile.component.js
@@ -202,8 +202,8 @@ export const RepositoryProfile = ({
 
       <View style={styles.unit}>
         <Text style={styles.unitNumber}>
-          {!isNaN(parseInt(repository.watchers_count, 10))
-            ? abbreviateNumber(repository.watchers_count)
+          {!isNaN(parseInt(repository.subscribers_count, 10))
+            ? abbreviateNumber(repository.subscribers_count)
             : ' '}
         </Text>
         <Text style={styles.unitText}>Watchers</Text>


### PR DESCRIPTION
I don't know what `watchers_count` means.

But in GitHub, `watch/star/fork` match `subscribers_count/stargazers_count/forks_count`.