### PR TITLE
fix(issue): fix rawtext error if comment.body equals to empty string

### DIFF
--- a/src/components/comment-list-item.component.js
+++ b/src/components/comment-list-item.component.js
@@ -293,7 +293,7 @@ class CommentListItemComponent extends Component {
           </View>
         </View>
 
-        {commentPresent &&
+        {!!commentPresent &&
           <View style={styles.commentContainer}>
             {comment.body_html &&
               comment.body_html !== '' &&


### PR DESCRIPTION
It is an annoying bug if you click into some issues, like #298, which have empty body.

> RawText "" must be wrapped in an explicit <Text> component.

The reason is:

```
const commentPresent =
      (comment.body_html && comment.body_html !== '') ||
      (comment.body && comment.body !== '')
```

In most cases, `commentPresent` is boolean. But if `!comment.body_html && comment.body === ''`, it is an empty string.