### PR TITLE
feat(comment-input): submit comment on clicking on the icon instead text

### DIFF
--- a/src/components/comment-input.component.js
+++ b/src/components/comment-input.component.js
@@ -23,7 +23,6 @@ const styles = StyleSheet.create({
   },
   wrapper: {
     padding: 10,
-    marginLeft: 5,
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
@@ -31,7 +30,6 @@ const styles = StyleSheet.create({
   textInput: {
     fontSize: normalize(12),
     flex: 1,
-    marginLeft: 15,
     marginRight: 5,
     color: colors.black,
     ...fonts.fontPrimaryLight,
@@ -40,11 +38,6 @@ const styles = StyleSheet.create({
     flex: 0.15,
     alignItems: 'flex-end',
     justifyContent: 'center',
-  },
-  postButton: {
-    fontSize: normalize(12),
-    letterSpacing: 1,
-    ...fonts.fontPrimarySemiBold,
   },
   postButtonDisabled: {
     color: colors.grey,
@@ -109,8 +102,6 @@ export class CommentInput extends Component {
           users={users}
         />
         <View style={styles.wrapper}>
-          <Icon name="send" color={colors.grey} />
-
           {userCanPost &&
             <TextInput
               underlineColorAndroid={'transparent'}
@@ -139,25 +130,23 @@ export class CommentInput extends Component {
               {translate('issue.main.lockedIssue', language)}
             </Text>}
 
-          {!this.props.issueLocked &&
+          {userCanPost &&
             <TouchableOpacity
               disabled={this.state.text === ''}
               style={styles.postButtonContainer}
               onPress={() => this.handleSubmit(this.state.text)}
             >
-              <Text
-                style={[
-                  styles.postButton,
+              <Icon
+                name="send"
+                iconStyle={
                   this.state.text === ''
                     ? styles.postButtonDisabled
-                    : styles.postButtonEnabled,
-                ]}
-              >
-                {translate('issue.main.commentButton', language)}
-              </Text>
+                    : styles.postButtonEnabled
+                }
+              />
             </TouchableOpacity>}
 
-          {this.props.issueLocked &&
+          {!userCanPost && this.props.issueLocked &&
             <View style={styles.postButtonContainer}>
               <Icon name="lock" type="octicon" color={colors.grey} />
             </View>}

--- a/src/locale/languages/en.js
+++ b/src/locale/languages/en.js
@@ -254,7 +254,6 @@ export const en = {
       noDescription: 'No description provided.',
       lockedCommentInput: 'Locked, but you can still comment...',
       commentInput: 'Add a comment...',
-      commentButton: 'Post',
       lockedIssue: 'Issue is locked',
       states: {
         open: 'Open',

--- a/src/locale/languages/fr.js
+++ b/src/locale/languages/fr.js
@@ -251,7 +251,6 @@ export const fr = {
       noDescription: 'Aucune description fournie.',
       lockedCommentInput: 'Verrouiller, mais vous pouvez encore commenter...',
       commentInput: 'Ajouter un commentaire...',
-      commentButton: 'Publier',
       lockedIssue: 'Ce ticket est verrouillé',
       states: {
         open: 'Ouvert',

--- a/src/locale/languages/nl.js
+++ b/src/locale/languages/nl.js
@@ -247,7 +247,6 @@ export const nl = {
       noDescription: 'Niet voorzien van een beschrijving.',
       lockedCommentInput: 'Gesloten maar je kan nog opmerkingen maken...',
       commentInput: 'Plaats opmerking...',
-      commentButton: 'Post',
       lockedIssue: 'Issue is gesloten',
       states: {
         open: 'Open',

--- a/src/locale/languages/pt-br.js
+++ b/src/locale/languages/pt-br.js
@@ -260,7 +260,6 @@ export const ptBr = {
       noDescription: 'Nenhuma descrição fornecida.',
       lockedCommentInput: 'Trancada, mas você ainda pode comentar...',
       commentInput: 'Adicionar um comentário...',
-      commentButton: 'Postar',
       lockedIssue: 'A issue está trancada',
       states: {
         open: 'Aberta',

--- a/src/locale/languages/tr.js
+++ b/src/locale/languages/tr.js
@@ -251,7 +251,6 @@ export const tr = {
       noDescription: 'Açıklama sağlanmadı.',
       lockedCommentInput: 'Kilitli, ancak yine de yorum yapabilirsiniz...',
       commentInput: 'Yorum ekle...',
-      commentButton: 'Ekle',
       lockedIssue: 'Issue kilitli',
       states: {
         open: 'Açık',


### PR DESCRIPTION
Now the send icon do nothing, although in many applications the message is sent by clicking on this icon, while the "Send" text is superfluous, so it was deleted. Now there is more free space for the text, which was the main point.

| Before | After
| - | -
| <img src="https://user-images.githubusercontent.com/4408379/30277482-98609f36-9710-11e7-85e1-87a415591d85.png" width="400"  /> | <img src="https://user-images.githubusercontent.com/4408379/30277481-9834b970-9710-11e7-9789-585b1090be57.png" width="400"  /> 

