### PR TITLE
refactor(api): Always use api.root instead of hardcoding api url

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -252,21 +252,21 @@ export async function fetchChangeIssueLockStatus(
 }
 
 export async function fetchSearch(type, query, accessToken, params = '') {
-  const ENDPOINT = `https://api.github.com/search/${type}?q=${query}${params}`;
+  const ENDPOINT = `${root}/search/${type}?q=${query}${params}`;
   const response = await fetch(ENDPOINT, accessTokenParameters(accessToken));
 
   return response.json();
 }
 
 export async function fetchNotifications(participating, all, accessToken) {
-  const ENDPOINT = `https://api.github.com/notifications?participating=${participating}&all=${all}`;
+  const ENDPOINT = `${root}/notifications?participating=${participating}&all=${all}`;
   const response = await fetch(ENDPOINT, accessTokenParameters(accessToken));
 
   return response.json();
 }
 
 export async function fetchMarkNotificationAsRead(notificationID, accessToken) {
-  const ENDPOINT = `https://api.github.com/notifications/threads/${notificationID}`;
+  const ENDPOINT = `${root}/notifications/threads/${notificationID}`;
   const response = await fetch(
     ENDPOINT,
     accessTokenParametersPATCH(null, accessToken)
@@ -279,7 +279,7 @@ export async function fetchMarkRepoNotificationAsRead(
   repoFullName,
   accessToken
 ) {
-  const ENDPOINT = `https://api.github.com/repos/${repoFullName}/notifications`;
+  const ENDPOINT = `${root}/repos/${repoFullName}/notifications`;
   const response = await fetch(ENDPOINT, accessTokenParametersPUT(accessToken));
 
   return response;
@@ -291,7 +291,7 @@ export async function fetchChangeStarStatusRepo(
   starred,
   accessToken
 ) {
-  const ENDPOINT = `https://api.github.com/user/starred/${owner}/${repo}`;
+  const ENDPOINT = `${root}/user/starred/${owner}/${repo}`;
   const response = await fetch(
     ENDPOINT,
     starred
@@ -303,7 +303,7 @@ export async function fetchChangeStarStatusRepo(
 }
 
 export async function fetchForkRepo(owner, repo, accessToken) {
-  const ENDPOINT = `https://api.github.com/repos/${owner}/${repo}/forks`;
+  const ENDPOINT = `${root}/repos/${owner}/${repo}/forks`;
   const response = await fetch(
     ENDPOINT,
     accessTokenParametersPOST(accessToken)
@@ -313,7 +313,7 @@ export async function fetchForkRepo(owner, repo, accessToken) {
 }
 
 export async function fetchStarCount(owner) {
-  const ENDPOINT = `https://api.github.com/users/${owner}/starred?per_page=1`;
+  const ENDPOINT = `${root}/users/${owner}/starred?per_page=1`;
   const response = await fetch(ENDPOINT);
 
   let linkHeader = response.headers.get('Link');
@@ -332,7 +332,7 @@ export async function fetchStarCount(owner) {
 }
 
 export async function watchRepo(isSubscribed, owner, repo, accessToken) {
-  const ENDPOINT = `https://api.github.com/repos/${owner}/${repo}/subscription`;
+  const ENDPOINT = `${root}/repos/${owner}/${repo}/subscription`;
   const response = await fetch(
     ENDPOINT,
     accessTokenParameters(accessToken, { subscribed: isSubscribed })
@@ -342,14 +342,14 @@ export async function watchRepo(isSubscribed, owner, repo, accessToken) {
 }
 
 export async function unWatchRepo(owner, repo, accessToken) {
-  const ENDPOINT = `https://api.github.com/repos/${owner}/${repo}/subscription`;
+  const ENDPOINT = `${root}/repos/${owner}/${repo}/subscription`;
   const response = await fetch(ENDPOINT, accessTokenParameters(accessToken));
 
   return response;
 }
 
 export async function fetchChangeFollowStatus(user, isFollowing, accessToken) {
-  const ENDPOINT = `https://api.github.com/user/following/${user}`;
+  const ENDPOINT = `${root}/user/following/${user}`;
   const response = await fetch(
     ENDPOINT,
     isFollowing
@@ -367,7 +367,7 @@ export async function fetchDiff(url, accessToken) {
 }
 
 export async function fetchMergeStatus(repo, issueNum, accessToken) {
-  const ENDPOINT = `https://api.github.com/repos/${repo}/pulls/${issueNum}/merge`;
+  const ENDPOINT = `${root}/repos/${repo}/pulls/${issueNum}/merge`;
   const response = await fetch(ENDPOINT, accessTokenParameters(accessToken));
 
   return response;
@@ -381,7 +381,7 @@ export async function fetchMergePullRequest(
   mergeMethod,
   accessToken
 ) {
-  const ENDPOINT = `https://api.github.com/repos/${repo}/pulls/${issueNum}/merge`;
+  const ENDPOINT = `${root}/repos/${repo}/pulls/${issueNum}/merge`;
 
   const response = await fetch(
     ENDPOINT,
@@ -402,7 +402,7 @@ export async function fetchSubmitNewIssue(
   issueComment,
   accessToken
 ) {
-  const ENDPOINT = `https://api.github.com/repos/${owner}/${repo}/issues`;
+  const ENDPOINT = `${root}/repos/${owner}/${repo}/issues`;
   const response = await fetch(
     ENDPOINT,
     accessTokenParametersPOST(accessToken, {

--- a/src/auth/screens/privacy-policy.screen.js
+++ b/src/auth/screens/privacy-policy.screen.js
@@ -4,6 +4,7 @@ import { StyleSheet, ScrollView, View, Text } from 'react-native';
 import { ViewContainer } from 'components';
 import { translate } from 'utils';
 import { colors, fonts, normalize } from 'config';
+import { root as apiRoot } from 'api';
 
 const styles = StyleSheet.create({
   container: {
@@ -118,8 +119,7 @@ export class PrivacyPolicyScreen extends Component {
                   style={styles.link}
                   onPress={() =>
                     navigation.navigate('Repository', {
-                      repositoryUrl:
-                        'https://api.github.com/repos/gitpoint/git-point',
+                      repositoryUrl: `${apiRoot}/repos/gitpoint/git-point`,
                     })}
                 >
                   {translate('auth.privacyPolicy.contactLink', language)}

--- a/src/components/issue-description.component.js
+++ b/src/components/issue-description.component.js
@@ -7,6 +7,7 @@ import moment from 'moment/min/moment-with-locales.min';
 import { StateBadge, MembersList, LabelButton, DiffBlocks } from 'components';
 import { translate } from 'utils';
 import { colors, fonts, normalize } from 'config';
+import { root as apiRoot } from 'api';
 
 const styles = StyleSheet.create({
   headerContainer: {
@@ -108,10 +109,7 @@ export class IssueDescription extends Component {
       <View style={(styles.container, styles.borderBottom)}>
         {issue.repository_url &&
           <ListItem
-            title={issue.repository_url.replace(
-              'https://api.github.com/repos/',
-              ''
-            )}
+            title={issue.repository_url.replace(`${apiRoot}/repos/`, '')}
             titleStyle={styles.titleSmall}
             leftIcon={{
               name: 'repo',

--- a/src/issue/screens/issue.screen.js
+++ b/src/issue/screens/issue.screen.js
@@ -16,6 +16,7 @@ import {
   CommentListItem,
   CommentInput,
 } from 'components';
+import { root as apiRoot } from 'api';
 import { translate } from 'utils';
 import { colors } from 'config';
 import { getRepository, getContributors } from 'repository';
@@ -121,8 +122,8 @@ class Issue extends Component {
     ) {
       navigation.navigate('Issue', {
         issueURL: node.attribs['data-url'].replace(
-          'github.com',
-          'api.github.com/repos'
+          'https://github.com',
+          `${apiRoot}/repos`
         ),
       });
     } else {
@@ -162,7 +163,7 @@ class Issue extends Component {
       if (
         issueParam &&
         repository.full_name !==
-          issueParam.repository_url.replace('https://api.github.com/repos/', '')
+          issueParam.repository_url.replace(`${apiRoot}/repos/`, '')
       ) {
         Promise.all([
           getRepositoryByDispatch(issue.repository_url),

--- a/src/notifications/screens/notifications.screen.js
+++ b/src/notifications/screens/notifications.screen.js
@@ -13,6 +13,7 @@ import {
 } from 'react-native';
 import { ButtonGroup, Card, Icon } from 'react-native-elements';
 
+import { root as apiRoot } from 'api';
 import {
   ViewContainer,
   LoadingContainer,
@@ -176,7 +177,7 @@ class Notifications extends Component {
     const { navigation } = this.props;
 
     navigation.navigate('Repository', {
-      repositoryUrl: `https://api.github.com/repos/${fullName}`,
+      repositoryUrl: `${apiRoot}/repos/${fullName}`,
     });
   };
 

--- a/src/repository/repository.action.js
+++ b/src/repository/repository.action.js
@@ -1,4 +1,5 @@
 import {
+  root as apiRoot,
   fetchUrl,
   fetchUrlNormal,
   fetchUrlFile,
@@ -219,13 +220,12 @@ export const getRepositoryInfo = url => {
       dispatch(getIssues(issuesUrl));
       dispatch(
         checkRepoStarred(
-          `https://api.github.com/user/starred/${repo.owner.login}/${repo.name}`
+          `${apiRoot}/user/starred/${repo.owner.login}/${repo.name}`
         )
       );
       dispatch(
         checkRepoSubscribed(
-          `https://api.github.com/repos/${repo.owner
-            .login}/${repo.name}/subscription`
+          `${apiRoot}/repos/${repo.owner.login}/${repo.name}/subscription`
         )
       );
     });


### PR DESCRIPTION
Fixes #302 