### PR TITLE
fix(ux): Fix user stars and repository watching status

### DIFF
--- a/src/components/user-profile.component.js
+++ b/src/components/user-profile.component.js
@@ -146,7 +146,7 @@ export const UserProfile = ({
       {type !== 'org' &&
         <TouchableOpacity style={styles.unit}>
           <Text style={styles.unitNumber}>
-            {starCount}
+            {!isNaN(parseInt(starCount, 10)) ? starCount : ' '}
           </Text>
           <Text style={styles.unitText}>
             {translate('common.stars', language)}

--- a/src/repository/screens/repository.screen.js
+++ b/src/repository/screens/repository.screen.js
@@ -236,7 +236,8 @@ class Repository extends Component {
     }
 
     const loader = isPendingFork ? <LoadingModal /> : null;
-    const isSubscribed = isPendingSubscribe ? false : subscribed;
+    const isSubscribed =
+      isPendingRepository || isPendingSubscribe ? false : subscribed;
     const isStarred =
       isPendingRepository || isPendingCheckStarred ? false : starred;
 


### PR DESCRIPTION
Fixes 2 small bugs while loading:
- The label "stars" in user profile is not kept in the same line with other labels.
- The "watching" badge in repository profile is not reset if the previous repository is watching.