### PR TITLE
feat(navigator): render tabs as needed

### DIFF
--- a/routes.js
+++ b/routes.js
@@ -370,5 +370,8 @@ export const GitPoint = StackNavigator(
   {
     headerMode: 'screen',
     URIPrefix: 'gitpoint://',
-  }
+    cardStyle: {
+      backgroundColor: 'transparent',
+    },
+  },
 );

--- a/routes.js
+++ b/routes.js
@@ -302,6 +302,7 @@ const MainTabNavigator = TabNavigator(
     },
   },
   {
+    lazy: true,
     tabBarPosition: 'bottom',
     tabBarOptions: {
       showLabel: false,


### PR DESCRIPTION
There is a [possibility](https://github.com/react-community/react-navigation/blob/master/docs/api/navigators/TabNavigator.md#tabnavigatorconfig) to render tabs as necessary, this would be useful to us, because now the initial load takes a long time because there are many requests (notifications, profile).

However, I noticed one unpleasant thing for me: when lazy loading of tab, you can see a gray background for a few seconds, I can not understand where it comes from and whether it can be replaced with a loading indicator. Would be glad if someone else looked this up!

