### PR TITLE
refactor(api): Api clean up

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -58,22 +58,18 @@ export const v3 = {
 
     return params;
   },
-
-  getJson: async (url, accessToken) => {
+  delete: async (url, accessToken) => {
     const response = await v3.call(
       url,
-      v3.parameters(accessToken, METHOD.GET, ACCEPT.JSON)
+      v3.parameters(accessToken, METHOD.DELETE)
     );
 
-    return response.json();
+    return response;
   },
-  getHtml: async (url, accessToken) => {
-    const response = await v3.call(
-      url,
-      v3.parameters(accessToken, METHOD.GET, ACCEPT.HTML)
-    );
+  get: async (url, accessToken) => {
+    const response = await v3.call(url, v3.parameters(accessToken));
 
-    return response.text();
+    return response;
   },
   getDiff: async (url, accessToken) => {
     const response = await v3.call(
@@ -83,6 +79,19 @@ export const v3 = {
 
     return response.text();
   },
+  getHtml: async (url, accessToken) => {
+    const response = await v3.call(
+      url,
+      v3.parameters(accessToken, METHOD.GET, ACCEPT.HTML)
+    );
+
+    return response.text();
+  },
+  getJson: async (url, accessToken) => {
+    const response = await v3.call(url, v3.parameters(accessToken));
+
+    return response.json();
+  },
   getRaw: async (url, accessToken) => {
     const response = await v3.call(
       url,
@@ -91,15 +100,15 @@ export const v3 = {
 
     return response.text();
   },
-  postJson: async (url, accessToken, body) => {
+  head: async (url, accessToken) => {
     const response = await v3.call(
       url,
-      v3.parameters(accessToken, METHOD.POST, ACCEPT.JSON, body)
+      v3.parameters(accessToken, METHOD.HEAD)
     );
 
-    return response.json();
+    return response;
   },
-  patch: async (url, accessToken, body) => {
+  patch: async (url, accessToken, body = {}) => {
     const response = await v3.call(
       url,
       v3.parameters(accessToken, METHOD.PATCH, ACCEPT.JSON, body)
@@ -107,29 +116,13 @@ export const v3 = {
 
     return response;
   },
-  delete: async (url, accessToken) => {
+  postJson: async (url, accessToken, body = {}) => {
     const response = await v3.call(
       url,
-      v3.parameters(accessToken, METHOD.DELETE, ACCEPT.JSON)
+      v3.parameters(accessToken, METHOD.POST, ACCEPT.JSON, body)
     );
 
-    return response;
-  },
-  put: async (url, accessToken, body = {}) => {
-    const response = await v3.call(
-      url,
-      v3.parameters(accessToken, METHOD.PUT, ACCEPT.JSON, body)
-    );
-
-    return response;
-  },
-  get: async (url, accessToken, body = {}) => {
-    const response = await v3.call(
-      url,
-      v3.parameters(accessToken, METHOD.GET, ACCEPT.JSON, body)
-    );
-
-    return response;
+    return response.json();
   },
   post: async (url, accessToken, body = {}) => {
     const response = await v3.call(
@@ -139,10 +132,10 @@ export const v3 = {
 
     return response;
   },
-  head: async (url, accessToken) => {
+  put: async (url, accessToken, body = {}) => {
     const response = await v3.call(
       url,
-      v3.parameters(accessToken, METHOD.HEAD, ACCEPT.JSON)
+      v3.parameters(accessToken, METHOD.PUT, ACCEPT.JSON, body)
     );
 
     return response;

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -121,12 +121,6 @@ export async function fetchUrlFile(url, accessToken) {
   return response.text();
 }
 
-export async function fetchCommentHTML(url, accessToken) {
-  const response = await fetch(url, accessTokenParameters(accessToken));
-
-  return response.json();
-}
-
 export async function fetchAccessToken(code, state) {
   const GITHUB_OAUTH_ENDPOINT = 'https://github.com/login/oauth/access_token';
   const response = await fetch(

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -212,13 +212,11 @@ export const fetchChangeIssueLockStatus = (
   issueNum,
   currentStatus,
   accessToken
-) => {
-  const ENDPOINT = `/repos/${owner}/${repoName}/issues/${issueNum}/lock`;
-
-  return currentStatus
-    ? v3.delete(ENDPOINT, accessToken)
-    : v3.put(ENDPOINT, accessToken);
-};
+) =>
+  v3[currentStatus ? 'delete' : 'put'](
+    `/repos/${owner}/${repoName}/issues/${issueNum}/lock`,
+    accessToken
+  );
 
 export const fetchSearch = (type, query, accessToken, params = '') =>
   v3.getJson(`/search/${type}?q=${query}${params}`, accessToken);
@@ -235,18 +233,8 @@ export const fetchMarkNotificationAsRead = (notificationID, accessToken) =>
 export const fetchMarkRepoNotificationAsRead = (repoFullName, accessToken) =>
   v3.put(`/repos/${repoFullName}/notifications`, accessToken);
 
-export const fetchChangeStarStatusRepo = (
-  owner,
-  repo,
-  starred,
-  accessToken
-) => {
-  const ENDPOINT = `/user/starred/${owner}/${repo}`;
-
-  return starred
-    ? v3.delete(ENDPOINT, accessToken)
-    : v3.put(ENDPOINT, accessToken);
-};
+export const fetchChangeStarStatusRepo = (owner, repo, starred, accessToken) =>
+  v3[starred ? 'delete' : 'put'](`/user/starred/${owner}/${repo}`, accessToken);
 
 export const fetchForkRepo = (owner, repo, accessToken) =>
   v3.post(`/repos/${owner}/${repo}/forks`, accessToken);
@@ -264,13 +252,8 @@ export const watchRepo = (owner, repo, accessToken) =>
 export const unWatchRepo = (owner, repo, accessToken) =>
   v3.delete(`/repos/${owner}/${repo}/subscription`, accessToken);
 
-export const fetchChangeFollowStatus = (user, isFollowing, accessToken) => {
-  const ENDPOINT = `/user/following/${user}`;
-
-  return isFollowing
-    ? v3.delete(ENDPOINT, accessToken)
-    : v3.put(ENDPOINT, accessToken);
-};
+export const fetchChangeFollowStatus = (user, isFollowing, accessToken) =>
+  v3[isFollowing ? 'delete' : 'put'](`/user/following/${user}`, accessToken);
 
 export const fetchDiff = (url, accessToken) => v3.getDiff(url, accessToken);
 
@@ -305,7 +288,7 @@ export const fetchSubmitNewIssue = (
 
 // Auth
 const authParameters = (code, state) => ({
-  method: 'POST',
+  method: METHOD.POST,
   headers: {
     Accept: 'application/json',
     'Content-Type': 'application/json',

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -9,79 +9,76 @@ export const CLIENT_SECRET = '3a70aee4d5e26c457720a31c3efe2f9062a4997a';
 export const root = 'https://api.github.com';
 export const USER_ENDPOINT = user => `${root}/users/${user}`;
 
-const accessTokenParameters = accessToken => ({
-  headers: {
-    Accept: 'application/vnd.github.v3+json',
-    Authorization: `token ${accessToken}`,
-    'Cache-Control': 'no-cache',
-  },
-});
+const ACCEPT = {
+  JSON: 'application/vnd.github.v3+json',
+  HTML: 'application/vnd.github.v3.html+json',
+  DIFF: 'application/vnd.github.v3.diff+json',
+  RAW: 'application/vnd.github.v3.raw+json',
+};
 
-const accessTokenParametersHEAD = accessToken => ({
-  method: 'HEAD',
-  headers: {
-    Accept: 'application/vnd.github.v3+json',
-    Authorization: `token ${accessToken}`,
-    'Cache-Control': 'no-cache',
-  },
-});
+const METHOD = {
+  GET: 'GET',
+  HEAD: 'HEAD',
+  PUT: 'PUT',
+  DELETE: 'DELETE',
+  PATCH: 'PATCH',
+  POST: 'POST',
+};
 
-const accessTokenParametersPUT = (accessToken, body = {}) => ({
-  method: 'PUT',
-  headers: {
-    Accept: 'application/vnd.github.v3+json',
-    Authorization: `token ${accessToken}`,
-    'Content-Length': 0,
-  },
-  body: JSON.stringify(body),
-});
+const apiCallParameters = (
+  accessToken,
+  method = METHOD.GET,
+  accept = ACCEPT.JSON,
+  body = {}
+) => {
+  const params = {
+    method,
+    headers: {
+      Accept: accept,
+      Authorization: `token ${accessToken}`,
+      'Cache-Control': 'no-cache',
+    },
+  };
 
-const accessTokenParametersDELETE = accessToken => ({
-  method: 'DELETE',
-  headers: {
-    Accept: 'application/vnd.github.v3+json',
-    Authorization: `token ${accessToken}`,
-  },
-});
+  if (
+    method === METHOD.PUT ||
+    method === METHOD.PATCH ||
+    method === METHOD.POST
+  ) {
+    params.body = JSON.stringify(body);
+    if (method === METHOD.PUT) {
+      params.headers['Content-Length'] = 0;
+    }
+  }
 
-const accessTokenParametersPATCH = (editParams, accessToken) => ({
-  method: 'PATCH',
-  headers: {
-    Accept: 'application/vnd.github.v3+json',
-    Authorization: `token ${accessToken}`,
-  },
-  body: JSON.stringify(editParams),
-});
+  return params;
+};
 
-const accessTokenParametersPOST = (accessToken, body) => ({
-  method: 'POST',
-  headers: {
-    Accept: 'application/vnd.github.v3+json',
-    Authorization: `token ${accessToken}`,
-  },
-  body: JSON.stringify(body),
-});
+const accessTokenParameters = accessToken => apiCallParameters(accessToken);
 
-const accessTokenParametersHTML = accessToken => ({
-  headers: {
-    Accept: 'application/vnd.github.v3.html+json',
-    Authorization: `token ${accessToken}`,
-  },
-});
+const accessTokenParametersHEAD = accessToken =>
+  apiCallParameters(accessToken, METHOD.HEAD);
 
-const accessTokenParametersDiff = accessToken => ({
-  headers: {
-    Accept: 'application/vnd.github.v3.diff+json',
-    Authorization: `token ${accessToken}`,
-  },
-});
+const accessTokenParametersPUT = (accessToken, body) =>
+  apiCallParameters(accessToken, METHOD.PUT, ACCEPT.JSON, body);
 
-const accessTokenParametersRaw = accessToken => ({
-  headers: {
-    Accept: 'application/vnd.github.v3.raw+json',
-    Authorization: `token ${accessToken}`,
-  },
-});
+const accessTokenParametersDELETE = accessToken =>
+  apiCallParameters(accessToken, METHOD.DELETE);
+
+const accessTokenParametersPATCH = (accessToken, editParams) =>
+  apiCallParameters(accessToken, METHOD.PATCH, ACCEPT.JSON, editParams);
+
+const accessTokenParametersPOST = (accessToken, body) =>
+  apiCallParameters(accessToken, METHOD.POST, ACCEPT.JSON, body);
+
+const accessTokenParametersHTML = accessToken =>
+  apiCallParameters(accessToken, METHOD.GET, ACCEPT.HTML);
+
+const accessTokenParametersDiff = accessToken =>
+  apiCallParameters(accessToken, METHOD.GET, ACCEPT.DIFF);
+
+const accessTokenParametersRaw = accessToken =>
+  apiCallParameters(accessToken, METHOD.GET, ACCEPT.RAW);
 
 const authParameters = (code, state) => ({
   method: 'POST',

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -153,138 +153,108 @@ const v3 = {
   },
 };
 
-export async function fetchUrl(url, accessToken) {
-  return v3.getJson(url, accessToken);
-}
+export const fetchUrl = (url, accessToken) => v3.getJson(url, accessToken);
 
-export async function fetchUrlNormal(url, accessToken) {
-  return v3.get(url, accessToken);
-}
+export const fetchUrlNormal = (url, accessToken) => v3.get(url, accessToken);
 
-export async function fetchUrlHead(url, accessToken) {
-  return v3.head(url, accessToken);
-}
+export const fetchUrlHead = (url, accessToken) => v3.head(url, accessToken);
 
-export async function fetchUrlFile(url, accessToken) {
-  return v3.getRaw(url, accessToken);
-}
+export const fetchUrlFile = (url, accessToken) => v3.getRaw(url, accessToken);
 
-export async function fetchAuthUser(accessToken) {
-  return v3.getJson('/user', accessToken);
-}
+export const fetchAuthUser = accessToken => v3.getJson('/user', accessToken);
 
-export async function fetchAuthUserOrgs(accessToken) {
-  return v3.getJson('/user/orgs', accessToken);
-}
+export const fetchAuthUserOrgs = accessToken =>
+  v3.getJson('/user/orgs', accessToken);
 
-export async function fetchUser(user, accessToken) {
-  return v3.getJson(`/users/${user}`, accessToken);
-}
+export const fetchUser = (user, accessToken) =>
+  v3.getJson(`/users/${user}`, accessToken);
 
-export async function fetchUserOrgs(user, accessToken) {
-  return v3.getJson(`/users/${user}/orgs`, accessToken);
-}
+export const fetchUserOrgs = (user, accessToken) =>
+  v3.getJson(`/users/${user}/orgs`, accessToken);
 
-export async function fetchUserEvents(user, accessToken) {
-  return v3.getJson(`/users/${user}/received_events?per_page=100`, accessToken);
-}
+export const fetchUserEvents = (user, accessToken) =>
+  v3.getJson(`/users/${user}/received_events?per_page=100`, accessToken);
 
-export async function fetchReadMe(user, repository, accessToken) {
-  return v3.getHtml(
-    `/repos/${user}/${repository}/readme?ref=master`,
-    accessToken
-  );
-}
+export const fetchReadMe = (user, repository, accessToken) =>
+  v3.getHtml(`/repos/${user}/${repository}/readme?ref=master`, accessToken);
 
-export async function fetchOrg(orgName, accessToken) {
-  return v3.getJson(`/orgs/${orgName}`, accessToken);
-}
+export const fetchOrg = (orgName, accessToken) =>
+  v3.getJson(`/orgs/${orgName}`, accessToken);
 
-export async function fetchOrgMembers(orgName, accessToken) {
-  return v3.getJson(`/orgs/${orgName}/members`, accessToken);
-}
+export const fetchOrgMembers = (orgName, accessToken) =>
+  v3.getJson(`/orgs/${orgName}/members`, accessToken);
 
-export async function fetchPostIssueComment(
+export const fetchPostIssueComment = (
   body,
   owner,
   repoName,
   issueNum,
   accessToken
-) {
-  return v3.postJson(
+) =>
+  v3.postJson(
     `/repos/${owner}/${repoName}/issues/${issueNum}/comments`,
     accessToken,
     { body }
   );
-}
 
-export async function fetchEditIssue(
+export const fetchEditIssue = (
   owner,
   repoName,
   issueNum,
   editParams,
   updateParams,
   accessToken
-) {
-  return v3.patch(
+) =>
+  v3.patch(
     `/repos/${owner}/${repoName}/issues/${issueNum}`,
     accessToken,
     editParams
   );
-}
 
-export async function fetchChangeIssueLockStatus(
+export const fetchChangeIssueLockStatus = (
   owner,
   repoName,
   issueNum,
   currentStatus,
   accessToken
-) {
+) => {
   const ENDPOINT = `/repos/${owner}/${repoName}/issues/${issueNum}/lock`;
 
   return currentStatus
     ? v3.delete(ENDPOINT, accessToken)
     : v3.put(ENDPOINT, accessToken);
-}
+};
 
-export async function fetchSearch(type, query, accessToken, params = '') {
-  return v3.getJson(`/search/${type}?q=${query}${params}`, accessToken);
-}
+export const fetchSearch = (type, query, accessToken, params = '') =>
+  v3.getJson(`/search/${type}?q=${query}${params}`, accessToken);
 
-export async function fetchNotifications(participating, all, accessToken) {
-  return v3.getJson(
+export const fetchNotifications = (participating, all, accessToken) =>
+  v3.getJson(
     `/notifications?participating=${participating}&all=${all}`,
     accessToken
   );
-}
 
-export async function fetchMarkNotificationAsRead(notificationID, accessToken) {
-  return v3.patch(`/notifications/threads/${notificationID}`, accessToken);
-}
+export const fetchMarkNotificationAsRead = (notificationID, accessToken) =>
+  v3.patch(`/notifications/threads/${notificationID}`, accessToken);
 
-export async function fetchMarkRepoNotificationAsRead(
-  repoFullName,
-  accessToken
-) {
-  return v3.put(`/repos/${repoFullName}/notifications`, accessToken);
-}
+export const fetchMarkRepoNotificationAsRead = (repoFullName, accessToken) =>
+  v3.put(`/repos/${repoFullName}/notifications`, accessToken);
 
-export async function fetchChangeStarStatusRepo(
+export const fetchChangeStarStatusRepo = (
   owner,
   repo,
   starred,
   accessToken
-) {
+) => {
   const ENDPOINT = `/user/starred/${owner}/${repo}`;
 
   return starred
     ? v3.delete(ENDPOINT, accessToken)
     : v3.put(ENDPOINT, accessToken);
-}
+};
 
-export async function fetchForkRepo(owner, repo, accessToken) {
-  return v3.post(`/repos/${owner}/${repo}/forks`, accessToken);
-}
+export const fetchForkRepo = (owner, repo, accessToken) =>
+  v3.post(`/repos/${owner}/${repo}/forks`, accessToken);
 
 export async function fetchStarCount(owner, accessToken) {
   const response = await v3.get(
@@ -307,63 +277,54 @@ export async function fetchStarCount(owner, accessToken) {
   return abbreviateNumber(output);
 }
 
-export async function isWatchingRepo(url, accessToken) {
-  return v3.head(url, accessToken);
-}
+export const isWatchingRepo = (url, accessToken) => v3.head(url, accessToken);
 
-export async function watchRepo(owner, repo, accessToken) {
-  return v3.put(`/repos/${owner}/${repo}/subscription`, accessToken, {
+export const watchRepo = (owner, repo, accessToken) =>
+  v3.put(`/repos/${owner}/${repo}/subscription`, accessToken, {
     subscribed: true,
   });
-}
 
-export async function unWatchRepo(owner, repo, accessToken) {
-  return v3.delete(`/repos/${owner}/${repo}/subscription`, accessToken);
-}
+export const unWatchRepo = (owner, repo, accessToken) =>
+  v3.delete(`/repos/${owner}/${repo}/subscription`, accessToken);
 
-export async function fetchChangeFollowStatus(user, isFollowing, accessToken) {
+export const fetchChangeFollowStatus = (user, isFollowing, accessToken) => {
   const ENDPOINT = `/user/following/${user}`;
 
   return isFollowing
     ? v3.delete(ENDPOINT, accessToken)
     : v3.put(ENDPOINT, accessToken);
-}
+};
 
-export async function fetchDiff(url, accessToken) {
-  return v3.getDiff(url, accessToken);
-}
+export const fetchDiff = (url, accessToken) => v3.getDiff(url, accessToken);
 
-export async function fetchMergeStatus(repo, issueNum, accessToken) {
-  return v3.get(`/repos/${repo}/pulls/${issueNum}/merge`, accessToken);
-}
+export const fetchMergeStatus = (repo, issueNum, accessToken) =>
+  v3.get(`/repos/${repo}/pulls/${issueNum}/merge`, accessToken);
 
-export async function fetchMergePullRequest(
+export const fetchMergePullRequest = (
   repo,
   issueNum,
   commitTitle,
   commitMessage,
   mergeMethod,
   accessToken
-) {
-  return v3.put(`/repos/${repo}/pulls/${issueNum}/merge`, accessToken, {
+) =>
+  v3.put(`/repos/${repo}/pulls/${issueNum}/merge`, accessToken, {
     commit_title: commitTitle,
     commit_message: commitMessage,
     merge_method: mergeMethod,
   });
-}
 
-export async function fetchSubmitNewIssue(
+export const fetchSubmitNewIssue = (
   owner,
   repo,
   issueTitle,
   issueComment,
   accessToken
-) {
-  return v3.postJson(`/repos/${owner}/${repo}/issues`, accessToken, {
+) =>
+  v3.postJson(`/repos/${owner}/${repo}/issues`, accessToken, {
     title: issueTitle,
     body: issueComment,
   });
-}
 
 // Auth
 const authParameters = (code, state) => ({

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -25,11 +25,10 @@ const METHOD = {
   POST: 'POST',
 };
 
-const v3 = {
+export const v3 = {
   root: 'https://api.github.com',
   call: async (url, parameters) => {
     const finalUrl = url.indexOf(v3.root) === 0 ? url : `${v3.root}${url}`;
-    // console.log('Calling url', finalUrl, parameters);
     const response = await fetch(finalUrl, parameters);
 
     return response;
@@ -152,14 +151,6 @@ const v3 = {
     return response;
   },
 };
-
-export const fetchUrl = (url, accessToken) => v3.getJson(url, accessToken);
-
-export const fetchUrlNormal = (url, accessToken) => v3.get(url, accessToken);
-
-export const fetchUrlHead = (url, accessToken) => v3.head(url, accessToken);
-
-export const fetchUrlFile = (url, accessToken) => v3.getRaw(url, accessToken);
 
 export const fetchAuthUser = accessToken => v3.getJson('/user', accessToken);
 

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -26,9 +26,11 @@ const METHOD = {
 };
 
 const v3 = {
+  root: 'https://api.github.com',
   call: async (url, parameters) => {
-    // console.log('Calling url', url, parameters);
-    const response = await fetch(url, parameters);
+    const finalUrl = url.indexOf(v3.root) === 0 ? url : `${v3.root}${url}`;
+    // console.log('Calling url', finalUrl, parameters);
+    const response = await fetch(finalUrl, parameters);
 
     return response;
   },
@@ -168,41 +170,38 @@ export async function fetchUrlFile(url, accessToken) {
 }
 
 export async function fetchAuthUser(accessToken) {
-  return v3.getJson(`${root}/user`, accessToken);
+  return v3.getJson('/user', accessToken);
 }
 
 export async function fetchAuthUserOrgs(accessToken) {
-  return v3.getJson(`${root}/user/orgs`, accessToken);
+  return v3.getJson('/user/orgs', accessToken);
 }
 
 export async function fetchUser(user, accessToken) {
-  return v3.getJson(`${root}/users/${user}`, accessToken);
+  return v3.getJson(`/users/${user}`, accessToken);
 }
 
 export async function fetchUserOrgs(user, accessToken) {
-  return v3.getJson(`${root}/users/${user}/orgs`, accessToken);
+  return v3.getJson(`/users/${user}/orgs`, accessToken);
 }
 
 export async function fetchUserEvents(user, accessToken) {
-  return v3.getJson(
-    `${root}/users/${user}/received_events?per_page=100`,
-    accessToken
-  );
+  return v3.getJson(`/users/${user}/received_events?per_page=100`, accessToken);
 }
 
 export async function fetchReadMe(user, repository, accessToken) {
   return v3.getHtml(
-    `${root}/repos/${user}/${repository}/readme?ref=master`,
+    `/repos/${user}/${repository}/readme?ref=master`,
     accessToken
   );
 }
 
 export async function fetchOrg(orgName, accessToken) {
-  return v3.getJson(`${root}/orgs/${orgName}`, accessToken);
+  return v3.getJson(`/orgs/${orgName}`, accessToken);
 }
 
 export async function fetchOrgMembers(orgName, accessToken) {
-  return v3.getJson(`${root}/orgs/${orgName}/members`, accessToken);
+  return v3.getJson(`/orgs/${orgName}/members`, accessToken);
 }
 
 export async function fetchPostIssueComment(
@@ -213,7 +212,7 @@ export async function fetchPostIssueComment(
   accessToken
 ) {
   return v3.postJson(
-    `${root}/repos/${owner}/${repoName}/issues/${issueNum}/comments`,
+    `/repos/${owner}/${repoName}/issues/${issueNum}/comments`,
     accessToken,
     { body }
   );
@@ -228,7 +227,7 @@ export async function fetchEditIssue(
   accessToken
 ) {
   return v3.patch(
-    `${root}/repos/${owner}/${repoName}/issues/${issueNum}`,
+    `/repos/${owner}/${repoName}/issues/${issueNum}`,
     accessToken,
     editParams
   );
@@ -241,7 +240,7 @@ export async function fetchChangeIssueLockStatus(
   currentStatus,
   accessToken
 ) {
-  const ENDPOINT = `${root}/repos/${owner}/${repoName}/issues/${issueNum}/lock`;
+  const ENDPOINT = `/repos/${owner}/${repoName}/issues/${issueNum}/lock`;
 
   return currentStatus
     ? v3.delete(ENDPOINT, accessToken)
@@ -249,28 +248,25 @@ export async function fetchChangeIssueLockStatus(
 }
 
 export async function fetchSearch(type, query, accessToken, params = '') {
-  return v3.getJson(`${root}/search/${type}?q=${query}${params}`, accessToken);
+  return v3.getJson(`/search/${type}?q=${query}${params}`, accessToken);
 }
 
 export async function fetchNotifications(participating, all, accessToken) {
   return v3.getJson(
-    `${root}/notifications?participating=${participating}&all=${all}`,
+    `/notifications?participating=${participating}&all=${all}`,
     accessToken
   );
 }
 
 export async function fetchMarkNotificationAsRead(notificationID, accessToken) {
-  return v3.patch(
-    `${root}/notifications/threads/${notificationID}`,
-    accessToken
-  );
+  return v3.patch(`/notifications/threads/${notificationID}`, accessToken);
 }
 
 export async function fetchMarkRepoNotificationAsRead(
   repoFullName,
   accessToken
 ) {
-  return v3.put(`${root}/repos/${repoFullName}/notifications`, accessToken);
+  return v3.put(`/repos/${repoFullName}/notifications`, accessToken);
 }
 
 export async function fetchChangeStarStatusRepo(
@@ -279,7 +275,7 @@ export async function fetchChangeStarStatusRepo(
   starred,
   accessToken
 ) {
-  const ENDPOINT = `${root}/user/starred/${owner}/${repo}`;
+  const ENDPOINT = `/user/starred/${owner}/${repo}`;
 
   return starred
     ? v3.delete(ENDPOINT, accessToken)
@@ -287,12 +283,12 @@ export async function fetchChangeStarStatusRepo(
 }
 
 export async function fetchForkRepo(owner, repo, accessToken) {
-  return v3.post(`${root}/repos/${owner}/${repo}/forks`, accessToken);
+  return v3.post(`/repos/${owner}/${repo}/forks`, accessToken);
 }
 
 export async function fetchStarCount(owner, accessToken) {
   const response = await v3.get(
-    `${root}/users/${owner}/starred?per_page=1`,
+    `/users/${owner}/starred?per_page=1`,
     accessToken
   );
 
@@ -316,17 +312,17 @@ export async function isWatchingRepo(url, accessToken) {
 }
 
 export async function watchRepo(owner, repo, accessToken) {
-  return v3.put(`${root}/repos/${owner}/${repo}/subscription`, accessToken, {
+  return v3.put(`/repos/${owner}/${repo}/subscription`, accessToken, {
     subscribed: true,
   });
 }
 
 export async function unWatchRepo(owner, repo, accessToken) {
-  return v3.delete(`${root}/repos/${owner}/${repo}/subscription`, accessToken);
+  return v3.delete(`/repos/${owner}/${repo}/subscription`, accessToken);
 }
 
 export async function fetchChangeFollowStatus(user, isFollowing, accessToken) {
-  const ENDPOINT = `${root}/user/following/${user}`;
+  const ENDPOINT = `/user/following/${user}`;
 
   return isFollowing
     ? v3.delete(ENDPOINT, accessToken)
@@ -338,7 +334,7 @@ export async function fetchDiff(url, accessToken) {
 }
 
 export async function fetchMergeStatus(repo, issueNum, accessToken) {
-  return v3.get(`${root}/repos/${repo}/pulls/${issueNum}/merge`, accessToken);
+  return v3.get(`/repos/${repo}/pulls/${issueNum}/merge`, accessToken);
 }
 
 export async function fetchMergePullRequest(
@@ -349,7 +345,7 @@ export async function fetchMergePullRequest(
   mergeMethod,
   accessToken
 ) {
-  return v3.put(`${root}/repos/${repo}/pulls/${issueNum}/merge`, accessToken, {
+  return v3.put(`/repos/${repo}/pulls/${issueNum}/merge`, accessToken, {
     commit_title: commitTitle,
     commit_message: commitMessage,
     merge_method: mergeMethod,
@@ -363,7 +359,7 @@ export async function fetchSubmitNewIssue(
   issueComment,
   accessToken
 ) {
-  return v3.postJson(`${root}/repos/${owner}/${repo}/issues`, accessToken, {
+  return v3.postJson(`/repos/${owner}/${repo}/issues`, accessToken, {
     title: issueTitle,
     body: issueComment,
   });

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -60,12 +60,14 @@ export const v3 = {
       url.indexOf('?') !== -1 ? `${url}&per_page=1` : `${url}?per_page=1`;
     const response = await v3.get(finalUrl, accessToken);
 
-    let linkHeader = response.headers.get('Link');
-    let number = 0;
+    if (response.status === 404) {
+      return 0;
+    }
 
-    if (linkHeader == null) {
-      number = response.json().length;
-    } else {
+    let linkHeader = response.headers.get('Link');
+    let number = 1;
+
+    if (linkHeader !== null) {
       linkHeader = linkHeader.match(/page=(\d)+/g).pop();
       number = linkHeader.split('=').pop();
     }

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -6,9 +6,6 @@ import { abbreviateNumber } from 'utils';
 export const CLIENT_ID = '87c7f05700c052937cfb';
 export const CLIENT_SECRET = '3a70aee4d5e26c457720a31c3efe2f9062a4997a';
 
-export const root = 'https://api.github.com';
-export const USER_ENDPOINT = user => `${root}/users/${user}`;
-
 const ACCEPT = {
   JSON: 'application/vnd.github.v3+json',
   HTML: 'application/vnd.github.v3.html+json',

--- a/src/auth/auth.action.js
+++ b/src/auth/auth.action.js
@@ -87,11 +87,12 @@ export const getUser = () => {
 
 export const getStarCount = () => {
   return (dispatch, getState) => {
+    const accessToken = getState().auth.accessToken;
     const user = getState().auth.user.login;
 
     dispatch({ type: GET_AUTH_STAR_COUNT.PENDING });
 
-    fetchStarCount(user)
+    fetchStarCount(user, accessToken)
       .then(data => {
         dispatch({
           type: GET_AUTH_STAR_COUNT.SUCCESS,

--- a/src/auth/screens/privacy-policy.screen.js
+++ b/src/auth/screens/privacy-policy.screen.js
@@ -4,7 +4,7 @@ import { StyleSheet, ScrollView, View, Text } from 'react-native';
 import { ViewContainer } from 'components';
 import { translate } from 'utils';
 import { colors, fonts, normalize } from 'config';
-import { root as apiRoot } from 'api';
+import { v3 } from 'api';
 
 const styles = StyleSheet.create({
   container: {
@@ -119,7 +119,7 @@ export class PrivacyPolicyScreen extends Component {
                   style={styles.link}
                   onPress={() =>
                     navigation.navigate('Repository', {
-                      repositoryUrl: `${apiRoot}/repos/gitpoint/git-point`,
+                      repositoryUrl: `${v3.root}/repos/gitpoint/git-point`,
                     })}
                 >
                   {translate('auth.privacyPolicy.contactLink', language)}

--- a/src/components/issue-description.component.js
+++ b/src/components/issue-description.component.js
@@ -7,7 +7,7 @@ import moment from 'moment/min/moment-with-locales.min';
 import { StateBadge, MembersList, LabelButton, DiffBlocks } from 'components';
 import { translate } from 'utils';
 import { colors, fonts, normalize } from 'config';
-import { root as apiRoot } from 'api';
+import { v3 } from 'api';
 
 const styles = StyleSheet.create({
   headerContainer: {
@@ -109,7 +109,7 @@ export class IssueDescription extends Component {
       <View style={(styles.container, styles.borderBottom)}>
         {issue.repository_url &&
           <ListItem
-            title={issue.repository_url.replace(`${apiRoot}/repos/`, '')}
+            title={issue.repository_url.replace(`${v3.root}/repos/`, '')}
             titleStyle={styles.titleSmall}
             leftIcon={{
               name: 'repo',

--- a/src/issue/issue.action.js
+++ b/src/issue/issue.action.js
@@ -1,12 +1,11 @@
 import {
-  fetchUrl,
-  fetchDiff,
   fetchMergeStatus,
   fetchPostIssueComment,
   fetchEditIssue,
   fetchChangeIssueLockStatus,
   fetchMergePullRequest,
-  accessTokenParametersPOST,
+  fetchSubmitNewIssue,
+  v3,
 } from 'api';
 import {
   GET_ISSUE_COMMENTS,
@@ -26,7 +25,8 @@ const getDiff = url => {
 
     dispatch({ type: GET_ISSUE_DIFF.PENDING });
 
-    return fetchDiff(url, accessToken)
+    return v3
+      .getDiff(url, accessToken)
       .then(data => {
         dispatch({
           type: GET_ISSUE_DIFF.SUCCESS,
@@ -79,7 +79,8 @@ export const getIssueComments = issueCommentsURL => {
 
     dispatch({ type: GET_ISSUE_COMMENTS.PENDING });
 
-    return fetchUrl(`${issueCommentsURL}?per_page=100`, accessToken)
+    return v3
+      .getJson(`${issueCommentsURL}?per_page=100`, accessToken)
       .then(data => {
         dispatch({
           type: GET_ISSUE_COMMENTS.SUCCESS,
@@ -190,7 +191,8 @@ export const getIssueFromUrl = url => {
 
     dispatch({ type: GET_ISSUE_FROM_URL.PENDING });
 
-    return fetchUrl(url, accessToken)
+    return v3
+      .getJson(url, accessToken)
       .then(issue => {
         dispatch({
           type: GET_ISSUE_FROM_URL.SUCCESS,
@@ -244,25 +246,6 @@ export const mergePullRequest = (
       });
   };
 };
-
-async function fetchSubmitNewIssue(
-  owner,
-  repo,
-  issueTitle,
-  issueComment,
-  accessToken
-) {
-  const ENDPOINT = `${root}/repos/${owner}/${repo}/issues`;
-  const response = await fetch(
-    ENDPOINT,
-    accessTokenParametersPOST(accessToken, {
-      title: issueTitle,
-      body: issueComment,
-    })
-  );
-
-  return response.json();
-}
 
 export const submitNewIssue = (owner, repo, issueTitle, issueComment) => {
   return (dispatch, getState) => {

--- a/src/issue/issue.action.js
+++ b/src/issue/issue.action.js
@@ -1,12 +1,12 @@
 import {
+  fetchUrl,
   fetchDiff,
   fetchMergeStatus,
-  fetchCommentHTML,
   fetchPostIssueComment,
   fetchEditIssue,
   fetchChangeIssueLockStatus,
   fetchMergePullRequest,
-  fetchSubmitNewIssue,
+  accessTokenParametersPOST,
 } from 'api';
 import {
   GET_ISSUE_COMMENTS,
@@ -79,7 +79,7 @@ export const getIssueComments = issueCommentsURL => {
 
     dispatch({ type: GET_ISSUE_COMMENTS.PENDING });
 
-    return fetchCommentHTML(`${issueCommentsURL}?per_page=100`, accessToken)
+    return fetchUrl(`${issueCommentsURL}?per_page=100`, accessToken)
       .then(data => {
         dispatch({
           type: GET_ISSUE_COMMENTS.SUCCESS,
@@ -190,7 +190,7 @@ export const getIssueFromUrl = url => {
 
     dispatch({ type: GET_ISSUE_FROM_URL.PENDING });
 
-    return fetchCommentHTML(url, accessToken)
+    return fetchUrl(url, accessToken)
       .then(issue => {
         dispatch({
           type: GET_ISSUE_FROM_URL.SUCCESS,
@@ -244,6 +244,25 @@ export const mergePullRequest = (
       });
   };
 };
+
+async function fetchSubmitNewIssue(
+  owner,
+  repo,
+  issueTitle,
+  issueComment,
+  accessToken
+) {
+  const ENDPOINT = `${root}/repos/${owner}/${repo}/issues`;
+  const response = await fetch(
+    ENDPOINT,
+    accessTokenParametersPOST(accessToken, {
+      title: issueTitle,
+      body: issueComment,
+    })
+  );
+
+  return response.json();
+}
 
 export const submitNewIssue = (owner, repo, issueTitle, issueComment) => {
   return (dispatch, getState) => {

--- a/src/issue/screens/issue.screen.js
+++ b/src/issue/screens/issue.screen.js
@@ -18,7 +18,7 @@ import {
   CommentListItem,
   CommentInput,
 } from 'components';
-import { root as apiRoot } from 'api';
+import { v3 } from 'api';
 import { translate } from 'utils';
 import { colors } from 'config';
 import { getRepository, getContributors } from 'repository';
@@ -150,7 +150,7 @@ class Issue extends Component {
 
     return node.attribs['data-url'].replace(
       'https://github.com',
-      `${apiRoot}/repos`
+      `${v3.root}/repos`
     );
   };
 
@@ -178,7 +178,7 @@ class Issue extends Component {
       if (
         issueParam &&
         repository.full_name !==
-          issueParam.repository_url.replace(`${apiRoot}/repos/`, '')
+          issueParam.repository_url.replace(`${v3.route}/repos/`, '')
       ) {
         Promise.all([
           getRepository(issue.repository_url),

--- a/src/notifications/screens/notifications.screen.js
+++ b/src/notifications/screens/notifications.screen.js
@@ -15,7 +15,7 @@ import {
 } from 'react-native';
 import { ButtonGroup, Card, Icon } from 'react-native-elements';
 
-import { root as apiRoot } from 'api';
+import { v3 } from 'api';
 import {
   ViewContainer,
   LoadingContainer,
@@ -179,7 +179,7 @@ class Notifications extends Component {
     const { navigation } = this.props;
 
     navigation.navigate('Repository', {
-      repositoryUrl: `${apiRoot}/repos/${fullName}`,
+      repositoryUrl: `${v3.root}/repos/${fullName}`,
     });
   };
 

--- a/src/organization/organization.action.js
+++ b/src/organization/organization.action.js
@@ -1,10 +1,6 @@
 import { createAction } from 'redux-actions';
 
-import {
-  fetchOrg,
-  fetchOrgMembers,
-  fetchUrl,
-} from 'api';
+import { fetchOrg, fetchOrgMembers, v3 } from 'api';
 import {
   GET_ORG,
   GET_ORG_LOADING,
@@ -51,7 +47,8 @@ export const fetchOrganizationRepos = url => (dispatch, getState) => {
   dispatch(getOrgReposLoading(true));
   dispatch(getOrgReposError(''));
 
-  fetchUrl(url, accessToken)
+  v3
+    .getJson(url, accessToken)
     .then(data => {
       dispatch(getOrgReposLoading(false));
       dispatch(getOrgRepos(data));

--- a/src/repository/repository.action.js
+++ b/src/repository/repository.action.js
@@ -10,6 +10,7 @@ import {
   fetchForkRepo,
   watchRepo,
   unWatchRepo,
+  isWatchingRepo,
 } from 'api';
 import {
   GET_REPOSITORY,
@@ -191,13 +192,13 @@ export const checkRepoSubscribed = url => {
 
     dispatch({ type: GET_REPOSITORY_SUBSCRIBED_STATUS.PENDING });
 
-    fetchUrlNormal(url, accessToken)
-      .then(data =>
+    isWatchingRepo(url, accessToken)
+      .then(data => {
         dispatch({
           type: GET_REPOSITORY_SUBSCRIBED_STATUS.SUCCESS,
           payload: data.status !== 404,
-        })
-      )
+        });
+      })
       .catch(error =>
         dispatch({
           type: GET_REPOSITORY_SUBSCRIBED_STATUS.ERROR,
@@ -284,13 +285,12 @@ export const changeStarStatusRepo = (owner, repo, starred) => {
 
 export const subscribeToRepo = (owner, repo) => (dispatch, getState) => {
   const accessToken = getState().auth.accessToken;
-  const isSubscribed = getState().repository.subscribed;
 
   dispatch({
     type: GET_REPOSITORY_SUBSCRIBED_STATUS.PENDING,
   });
 
-  return watchRepo(!isSubscribed, owner, repo, accessToken)
+  return watchRepo(owner, repo, accessToken)
     .then(data => data.json())
     .then(result => {
       dispatch({

--- a/src/repository/repository.action.js
+++ b/src/repository/repository.action.js
@@ -1,5 +1,4 @@
 import {
-  root as apiRoot,
   fetchReadMe,
   fetchSearch,
   fetchChangeStarStatusRepo,
@@ -248,17 +247,17 @@ export const getRepositoryInfo = url => {
       dispatch(getIssues(issuesUrl));
       dispatch(
         checkReadMe(
-          `${apiRoot}/repos/${repo.owner.login}/${repo.name}/readme?ref=master`
+          `${v3.root}/repos/${repo.owner.login}/${repo.name}/readme?ref=master`
         )
       );
       dispatch(
         checkRepoStarred(
-          `${apiRoot}/user/starred/${repo.owner.login}/${repo.name}`
+          `${v3.root}/user/starred/${repo.owner.login}/${repo.name}`
         )
       );
       dispatch(
         checkRepoSubscribed(
-          `${apiRoot}/repos/${repo.owner.login}/${repo.name}/subscription`
+          `${v3.root}/repos/${repo.owner.login}/${repo.name}/subscription`
         )
       );
     });

--- a/src/repository/repository.action.js
+++ b/src/repository/repository.action.js
@@ -1,9 +1,5 @@
 import {
   root as apiRoot,
-  fetchUrl,
-  fetchUrlNormal,
-  fetchUrlHead,
-  fetchUrlFile,
   fetchReadMe,
   fetchSearch,
   fetchChangeStarStatusRepo,
@@ -11,6 +7,7 @@ import {
   watchRepo,
   unWatchRepo,
   isWatchingRepo,
+  v3,
 } from 'api';
 import {
   GET_REPOSITORY,
@@ -37,7 +34,8 @@ export const getRepository = url => {
 
     dispatch({ type: GET_REPOSITORY.PENDING });
 
-    return fetchUrl(url, accessToken)
+    return v3
+      .getJson(url, accessToken)
       .then(data => {
         dispatch({
           type: GET_REPOSITORY.SUCCESS,
@@ -59,7 +57,8 @@ export const getContributors = url => {
 
     dispatch({ type: GET_REPOSITORY_CONTRIBUTORS.PENDING });
 
-    fetchUrl(url, accessToken)
+    v3
+      .getJson(url, accessToken)
       .then(data => {
         dispatch({
           type: GET_REPOSITORY_CONTRIBUTORS.SUCCESS,
@@ -81,7 +80,8 @@ export const getContents = (url, level) => {
 
     dispatch({ type: GET_REPOSITORY_CONTENTS.PENDING });
 
-    fetchUrl(url, accessToken)
+    v3
+      .getJson(url, accessToken)
       .then(data => {
         dispatch({
           type: GET_REPOSITORY_CONTENTS.SUCCESS,
@@ -104,7 +104,8 @@ export const getRepositoryFile = url => {
 
     dispatch({ type: GET_REPOSITORY_FILE.PENDING });
 
-    fetchUrlFile(url, accessToken)
+    v3
+      .getRaw(url, accessToken)
       .then(data => {
         dispatch({
           type: GET_REPOSITORY_FILE.SUCCESS,
@@ -126,7 +127,8 @@ export const getIssues = url => {
 
     dispatch({ type: GET_REPOSITORY_ISSUES.PENDING });
 
-    fetchUrl(url, accessToken)
+    v3
+      .getJson(url, accessToken)
       .then(data => {
         dispatch({
           type: GET_REPOSITORY_ISSUES.SUCCESS,
@@ -148,7 +150,8 @@ export const checkReadMe = url => {
 
     dispatch({ type: GET_REPO_README_STATUS.PENDING });
 
-    fetchUrlHead(url, accessToken)
+    v3
+      .head(url, accessToken)
       .then(data => {
         dispatch({
           type: GET_REPO_README_STATUS.SUCCESS,
@@ -170,7 +173,8 @@ export const checkRepoStarred = url => {
 
     dispatch({ type: GET_REPO_STARRED_STATUS.PENDING });
 
-    fetchUrlNormal(url, accessToken)
+    v3
+      .get(url, accessToken)
       .then(data => {
         dispatch({
           type: GET_REPO_STARRED_STATUS.SUCCESS,
@@ -360,7 +364,8 @@ export const getLabels = url => {
 
     dispatch({ type: GET_REPOSITORY_LABELS.PENDING });
 
-    fetchUrl(url, accessToken)
+    v3
+      .getJson(url, accessToken)
       .then(data => {
         dispatch({
           type: GET_REPOSITORY_LABELS.SUCCESS,

--- a/src/repository/repository.action.js
+++ b/src/repository/repository.action.js
@@ -4,7 +4,6 @@ import {
   fetchUrlNormal,
   fetchUrlHead,
   fetchUrlFile,
-  fetchCommentHTML,
   fetchReadMe,
   fetchSearch,
   fetchChangeStarStatusRepo,
@@ -126,7 +125,7 @@ export const getIssues = url => {
 
     dispatch({ type: GET_REPOSITORY_ISSUES.PENDING });
 
-    fetchCommentHTML(url, accessToken)
+    fetchUrl(url, accessToken)
       .then(data => {
         dispatch({
           type: GET_REPOSITORY_ISSUES.SUCCESS,

--- a/src/user/user.action.js
+++ b/src/user/user.action.js
@@ -72,7 +72,10 @@ const checkFollowStatusHelper = (user, followedUser, actionSet) => {
 
     dispatch({ type: actionSet.PENDING });
 
-    fetchUrlNormal(`${USER_ENDPOINT(user)}/following/${followedUser}`, accessToken)
+    fetchUrlNormal(
+      `${USER_ENDPOINT(user)}/following/${followedUser}`,
+      accessToken
+    )
       .then(data => {
         dispatch({
           type: actionSet.SUCCESS,
@@ -124,18 +127,17 @@ export const getFollowers = user => {
 
 export const getUserInfo = user => {
   return dispatch => {
-    Promise.all([
-      dispatch(getUser(user)),
-      dispatch(getOrgs(user)),
-    ]);
+    Promise.all([dispatch(getUser(user)), dispatch(getOrgs(user))]);
   };
 };
 
 export const getStarCount = user => {
-  return dispatch => {
+  return (dispatch, getState) => {
+    const accessToken = getState().auth.accessToken;
+
     dispatch({ type: GET_STAR_COUNT.PENDING });
 
-    fetchStarCount(user)
+    fetchStarCount(user, accessToken)
       .then(data => {
         dispatch({
           type: GET_STAR_COUNT.SUCCESS,

--- a/src/user/user.action.js
+++ b/src/user/user.action.js
@@ -1,10 +1,8 @@
 import {
   fetchUser,
   fetchUserOrgs,
-  USER_ENDPOINT,
   fetchSearch,
   fetchChangeFollowStatus,
-  root as apiRoot,
   fetchStarCount,
   v3,
 } from 'api';
@@ -72,7 +70,7 @@ const checkFollowStatusHelper = (user, followedUser, actionSet) => {
     dispatch({ type: actionSet.PENDING });
 
     v3
-      .head(`${USER_ENDPOINT(user)}/following/${followedUser}`, accessToken)
+      .head(`/users/${user}/following/${followedUser}`, accessToken)
       .then(data => {
         dispatch({
           type: actionSet.SUCCESS,
@@ -107,10 +105,7 @@ export const getFollowers = user => {
     dispatch({ type: GET_FOLLOWERS.PENDING });
 
     v3
-      .getJson(
-        `${USER_ENDPOINT(user.login)}/followers?per_page=100`,
-        accessToken
-      )
+      .getJson(`/users/${user.login}/followers?per_page=100`, accessToken)
       .then(data => {
         dispatch({
           type: GET_FOLLOWERS.SUCCESS,
@@ -186,8 +181,8 @@ export const getRepositories = user => {
     dispatch({ type: GET_REPOSITORIES.PENDING });
 
     const url = isAuthUser
-      ? `${apiRoot}/user/repos?affiliation=owner&sort=updated&per_page=50`
-      : `${USER_ENDPOINT(user.login)}/repos?sort=updated&per_page=50`;
+      ? '/user/repos?affiliation=owner&sort=updated&per_page=50'
+      : `/users/${user.login}/repos?sort=updated&per_page=50`;
 
     v3
       .getJson(url, accessToken)
@@ -213,10 +208,7 @@ export const getFollowing = user => {
     dispatch({ type: GET_FOLLOWING.PENDING });
 
     v3
-      .getJson(
-        `${USER_ENDPOINT(user.login)}/following?per_page=100`,
-        accessToken
-      )
+      .getJson(`/users/${user.login}/following?per_page=100`, accessToken)
       .then(data => {
         dispatch({
           type: GET_FOLLOWING.SUCCESS,

--- a/src/user/user.action.js
+++ b/src/user/user.action.js
@@ -1,13 +1,12 @@
 import {
   fetchUser,
   fetchUserOrgs,
-  fetchUrl,
-  fetchUrlNormal,
   USER_ENDPOINT,
   fetchSearch,
   fetchChangeFollowStatus,
   root as apiRoot,
   fetchStarCount,
+  v3,
 } from 'api';
 import {
   GET_USER,
@@ -72,10 +71,8 @@ const checkFollowStatusHelper = (user, followedUser, actionSet) => {
 
     dispatch({ type: actionSet.PENDING });
 
-    fetchUrlNormal(
-      `${USER_ENDPOINT(user)}/following/${followedUser}`,
-      accessToken
-    )
+    v3
+      .head(`${USER_ENDPOINT(user)}/following/${followedUser}`, accessToken)
       .then(data => {
         dispatch({
           type: actionSet.SUCCESS,
@@ -109,7 +106,11 @@ export const getFollowers = user => {
 
     dispatch({ type: GET_FOLLOWERS.PENDING });
 
-    fetchUrl(`${USER_ENDPOINT(user.login)}/followers?per_page=100`, accessToken)
+    v3
+      .getJson(
+        `${USER_ENDPOINT(user.login)}/followers?per_page=100`,
+        accessToken
+      )
       .then(data => {
         dispatch({
           type: GET_FOLLOWERS.SUCCESS,
@@ -188,7 +189,8 @@ export const getRepositories = user => {
       ? `${apiRoot}/user/repos?affiliation=owner&sort=updated&per_page=50`
       : `${USER_ENDPOINT(user.login)}/repos?sort=updated&per_page=50`;
 
-    fetchUrl(url, accessToken)
+    v3
+      .getJson(url, accessToken)
       .then(data => {
         dispatch({
           type: GET_REPOSITORIES.SUCCESS,
@@ -210,7 +212,11 @@ export const getFollowing = user => {
 
     dispatch({ type: GET_FOLLOWING.PENDING });
 
-    fetchUrl(`${USER_ENDPOINT(user.login)}/following?per_page=100`, accessToken)
+    v3
+      .getJson(
+        `${USER_ENDPOINT(user.login)}/following?per_page=100`,
+        accessToken
+      )
       .then(data => {
         dispatch({
           type: GET_FOLLOWING.SUCCESS,


### PR DESCRIPTION
While looking at redux, I came accros a few facts with api/index.js : 

- `fetch()` is being called in a lot of functions, inside and outside `api/index.js`. Some actions files also borrowed the accessTokenParameters* helpers.
- weird function naming: `fetchUrl` for GET returning json, and `fetchNormal` for GET returning a `Response`
- duplicate functions: `fetchUrlCommentsHTML` was in fact performing the exact same thing as `fetchUrl`
- code was piling up and the file was getting unmaintainable.

This PR cleans up all this, and makes the API crystal clear, by introducing the `v3` namespace:

v3 is a simple object representing our GitHub Rest API v3 client :
- `v3.call()` is the only function that calls GitHub. It receives the `url` and `parameters` arguments for the `fetch()` call and returns a Response
- `v3.root` is the root endpoint
- `v3.parameters()` is the sole responsible for preparing the `fetch()` call parameters. It takes the accessToken **(mandatory)**, the HTTP method *(optional)*, the Accept header  *(optional)* and a body for the request *(optional)*, does its magic, and returns the correct object.
- The rest of the object consist of helpers method using a clear nomenclature : 
       **httpVerb** **AcceptedResult** ()

For example:
  - `v3.get()` performs a `GET` query and returns the `Response`
  - `v3.getJson()` performs a `GET` query and returns the .json() response
  - `v3.head()` performs a `HEAD` query and returns the `Response`
  - `v3.postRaw()` performs a `POST` request with the given object and returns the .text() response

I implemented all the needed helpers, and if a new combination arises (`postHtml()` for example), it should be added in v3 following this nomenclature.

I also adopted two enums, `METHOD` and `ACCEPT` to attempt to standardize things a bit more.

This clean up made obvious that `fetchStarCount()` was missing the accessToken, and that some weird calls were made by the watch/unwatch actions. I fixed the calls.

I did my best to test all the apps, but I might have missed a few spots, please let me know if it's the case!

Next step (once this is merged), is to re-dispatch all remaining functions (aside v3 of course) from `api/index.js` to the actions files where they belong.