### PR TITLE
refactor(languages): change pt-br flag and add emojiCode to languages

### DIFF
--- a/src/auth/screens/language-settings.js
+++ b/src/auth/screens/language-settings.js
@@ -1,27 +1,32 @@
 export default [
   {
     code: 'en',
-    emojiCode: 'us',
+    emojiCode: ':flag-us:',
     name: 'English',
   },
   {
     code: 'fr',
+    emojiCode: ':flag-fr:',
     name: 'Français',
   },
   {
     code: 'nl',
+    emojiCode: ':flag-nl:',
     name: 'Nederlands',
   },
   {
     code: 'tr',
+    emojiCode: ':flag-tr:',
     name: 'Türkçe',
   },
   {
     code: 'pt-br',
+    emojiCode: ':flag-br:',
     name: 'Português do Brasil',
   },
   {
     code: 'ru',
+    emojiCode: ':flag-ru:',
     name: 'Русский',
   },
 ];

--- a/src/auth/screens/user-options.screen.js
+++ b/src/auth/screens/user-options.screen.js
@@ -152,14 +152,12 @@ class UserOptions extends Component {
             <FlatList
               data={languages}
               renderItem={({ item }) => {
-                const langCode = item.emojiCode || item.code.substring(0, 2);
-
                 return (
                   <ListItem
                     title={
                       <View style={styles.language}>
                         <Text style={styles.flag}>
-                          {emojifyText(`:flag-${langCode}:`)}
+                          {emojifyText(item.emojiCode)}
                         </Text>
                         <Text style={styles.listTitle}>
                           {item.name}


### PR DESCRIPTION
Just a small addition to the great job from @lex111 

- Add the correct flag of **pt-br** language, in this case the Brazilian flag.
- Add emojiCode directly to language settings.