### PR TITLE
fix(loading-container): make correct center align

### DIFF
--- a/src/components/loading-indicators/loading-container.component.js
+++ b/src/components/loading-indicators/loading-container.component.js
@@ -18,21 +18,15 @@ const styles = StyleSheet.create({
   center: {
     justifyContent: 'center',
   },
-  loadingIcon: {
-    height: 80,
-  },
   text: {
+    paddingTop: 20,
     ...fonts.fontPrimary,
   },
 });
 
 export const LoadingContainer = ({ animating, text, center }: Props) =>
   <View style={[styles.loadingContainer, center && styles.center]}>
-    <ActivityIndicator
-      animating={animating}
-      style={styles.loadingIcon}
-      size="large"
-    />
+    <ActivityIndicator animating={animating} size="large" />
     {text &&
       <Text style={styles.text}>
         {text}


### PR DESCRIPTION
I do not know why the height of the activity indicator is specified, but because of this, the entire block is not quite aligned correctly in the center. Therefore, instead I propose to indent text from the indicator through padding property.