### PR TITLE
refactor(profile): show user data when it is fully loaded

### DIFF
--- a/App.js
+++ b/App.js
@@ -59,7 +59,11 @@ class App extends Component {
 
     persistStore(
       configureStore,
-      { storage: AsyncStorage, transforms: [encryptor] },
+      {
+        storage: AsyncStorage,
+        transforms: [encryptor],
+        blacklist: ['user'],
+      },
       () => {
         this.setState({ rehydrated: true });
       }

--- a/src/auth/auth.reducer.js
+++ b/src/auth/auth.reducer.js
@@ -84,7 +84,6 @@ export const authReducer = (state = initialState, action = {}) => {
     case GET_AUTH_STAR_COUNT.PENDING:
       return {
         ...state,
-        starCount: ' ',
         isPendingStarCount: true,
       };
     case GET_AUTH_STAR_COUNT.SUCCESS:

--- a/src/auth/screens/auth-profile.screen.js
+++ b/src/auth/screens/auth-profile.screen.js
@@ -123,7 +123,7 @@ class AuthProfile extends Component {
               type="user"
               initialUser={hasInitialUser ? user : {}}
               user={hasInitialUser ? user : {}}
-              starCount={starCount}
+              starCount={hasInitialUser ? starCount : ''}
               language={language}
               navigation={navigation}
             />}

--- a/src/user/screens/profile.screen.js
+++ b/src/user/screens/profile.screen.js
@@ -102,13 +102,7 @@ class Profile extends Component {
   }
 
   componentDidMount() {
-    const user = this.props.navigation.state.params.user;
-    const auth = this.props.auth;
-
-    this.props.getUserInfo(user.login);
-    this.props.getStarCount(user.login);
-    this.props.getIsFollowing(user.login, auth.login);
-    this.props.getIsFollower(user.login, auth.login);
+    this.getUserInfo();
   }
 
   getUserInfo = () => {
@@ -162,6 +156,13 @@ class Profile extends Component {
         ? translate('user.profile.unfollow', language)
         : translate('user.profile.follow', language),
     ];
+    const isAllDataLoaded =
+      initialUser.login === user.login &&
+      !(
+        isPendingStarCount ||
+        isPendingCheckFollowing ||
+        isPendingCheckFollower
+      );
 
     return (
       <ViewContainer>
@@ -170,14 +171,10 @@ class Profile extends Component {
             <UserProfile
               type="user"
               initialUser={initialUser}
-              starCount={isPendingStarCount ? '' : starCount}
-              isFollowing={
-                isPendingUser || isPendingCheckFollowing ? false : isFollowing
-              }
-              isFollower={
-                isPendingUser || isPendingCheckFollower ? false : isFollower
-              }
-              user={initialUser.login === user.login ? user : {}}
+              starCount={isAllDataLoaded ? starCount : ''}
+              isFollowing={!isAllDataLoaded ? false : isFollowing}
+              isFollower={!isAllDataLoaded ? false : isFollower}
+              user={isAllDataLoaded ? user : {}}
               language={language}
               navigation={navigation}
             />}

--- a/src/user/user.reducer.js
+++ b/src/user/user.reducer.js
@@ -15,7 +15,7 @@ const initialState = {
   user: {},
   orgs: [],
   isFollowing: false, // auth is following user
-  isFollower: false,  // user is a follower of auth, as well as user is following auth
+  isFollower: false, // user is a follower of auth, as well as user is following auth
   repositories: [],
   followers: [],
   following: [],
@@ -71,7 +71,6 @@ export const userReducer = (state = initialState, action = {}) => {
     case GET_STAR_COUNT.PENDING:
       return {
         ...state,
-        starCount: ' ',
         isPendingStarCount: true,
       };
     case GET_STAR_COUNT.SUCCESS:


### PR DESCRIPTION
This avoids the problem shown below: i.e. the number of stars has not yet loaded, and the number of repositories has already appeared, but you need to wait until all the data is loaded and only then show them all.

Before | After
| - | -
| <img src="https://user-images.githubusercontent.com/4408379/30869856-e7efeb2a-a2ea-11e7-8edd-6e5c1fa0bf04.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/4408379/30869858-e9495c86-a2ea-11e7-90cc-3887a10c7718.gif" width="300" />

