### PR TITLE
refactor(profile): rename and extend messages for following and followers

### DIFF
--- a/src/components/user-profile.component.js
+++ b/src/components/user-profile.component.js
@@ -158,7 +158,7 @@ export const UserProfile = ({
           style={styles.unit}
           onPress={() =>
             navigation.navigate('FollowerList', {
-              title: translate('user.followerList.title', language),
+              title: translate('user.followers.title', language),
               user,
               followerCount: user.followers > 15 ? 15 : user.followers,
             })}
@@ -167,11 +167,11 @@ export const UserProfile = ({
             {!isNaN(parseInt(user.followers, 10)) ? user.followers : ' '}
           </Text>
           <Text style={styles.unitText}>
-            {translate('common.followers', language)}
+            {translate('user.followers.text', language)}
           </Text>
           {isFollowing &&
             <Text style={[styles.unitStatus, styles.badge]}>
-              {translate('common.following', language)}
+              {translate('user.following.followingYou', language)}
             </Text>}
         </TouchableOpacity>}
 
@@ -180,7 +180,7 @@ export const UserProfile = ({
           style={styles.unit}
           onPress={() =>
             navigation.navigate('FollowingList', {
-              title: translate('user.followingList.title', language),
+              title: translate('user.following.title', language),
               user,
               followingCount: user.following > 15 ? 15 : user.following,
             })}
@@ -189,11 +189,11 @@ export const UserProfile = ({
             {!isNaN(parseInt(user.following, 10)) ? user.following : ' '}
           </Text>
           <Text style={styles.unitText}>
-            {translate('common.following', language)}
+            {translate('user.following.text', language)}
           </Text>
           {isFollower &&
             <Text style={[styles.unitStatus, styles.badge]}>
-              {translate('user.followYou.title')}
+              {translate('user.followers.followsYou')}
             </Text>}
         </TouchableOpacity>}
     </View>

--- a/src/locale/languages/en.js
+++ b/src/locale/languages/en.js
@@ -158,14 +158,15 @@ export const en = {
     repositoryList: {
       title: 'Repositories',
     },
-    followerList: {
+    followers: {
       title: 'Followers',
+      text: 'Followers',
+      followsYou: 'Follows you',
     },
-    followingList: {
+    following: {
       title: 'Following',
-    },
-    followYou: {
-      title: 'Follows you',
+      text: 'Following',
+      followingYou: 'Following',
     },
   },
   repository: {
@@ -302,8 +303,6 @@ export const en = {
     email: 'Email',
     website: 'Website',
     repositories: 'Repositories',
-    followers: 'Followers',
-    following: 'Following',
     cancel: 'Cancel',
     yes: 'Yes',
     ok: 'OK',

--- a/src/locale/languages/fr.js
+++ b/src/locale/languages/fr.js
@@ -158,14 +158,15 @@ export const fr = {
     repositoryList: {
       title: 'Dépôts',
     },
-    followerList: {
+    followers: {
       title: 'Followers',
+      text: 'Followers',
+      followsYou: 'Vous suit',
     },
-    followingList: {
+    following: {
       title: 'Following',
-    },
-    followYou: {
-      title: 'Vous suit',
+      text: 'Following',
+      followingYou: 'Following',
     },
   },
   repository: {
@@ -299,8 +300,6 @@ export const fr = {
     email: 'Email',
     website: 'Site web',
     repositories: 'Dépôts',
-    followers: 'Followers',
-    following: 'Following',
     cancel: 'Annuler',
     yes: 'Oui',
     ok: 'OK',

--- a/src/locale/languages/nl.js
+++ b/src/locale/languages/nl.js
@@ -154,14 +154,15 @@ export const nl = {
     repositoryList: {
       title: 'Repositories',
     },
-    followerList: {
+    followers: {
       title: 'Volgers',
+      text: 'Volgers',
+      followsYou: 'Volgt jou',
     },
-    followingList: {
+    following: {
       title: 'Volgen',
-    },
-    followYou: {
-      title: 'Volgt jou',
+      text: 'Volgen',
+      followingYou: 'Volgen',
     },
   },
   repository: {
@@ -295,8 +296,6 @@ export const nl = {
     email: 'Email',
     website: 'Website',
     repositories: 'Repositories',
-    followers: 'Volgers',
-    following: 'Volgen',
     cancel: 'Annuleren',
     yes: 'Ja',
     ok: 'OKE',

--- a/src/locale/languages/pt-br.js
+++ b/src/locale/languages/pt-br.js
@@ -155,14 +155,15 @@ export const ptBr = {
     repositoryList: {
       title: 'Repositórios',
     },
-    followerList: {
+    followers: {
       title: 'Seguidores',
+      text: 'Seguidores',
+      followsYou: 'Segue você',
     },
-    followingList: {
+    following: {
       title: 'Seguindo',
-    },
-    followYou: {
-      title: 'Segue você',
+      text: 'Seguindo',
+      followingYou: 'Seguindo',
     },
   },
   repository: {
@@ -299,8 +300,6 @@ export const ptBr = {
     email: 'E-mail',
     website: 'Website',
     repositories: 'Repositórios',
-    followers: 'Seguidores',
-    following: 'Seguindo',
     cancel: 'Cancelar',
     yes: 'Sim',
     ok: 'OK',

--- a/src/locale/languages/ru.js
+++ b/src/locale/languages/ru.js
@@ -153,14 +153,15 @@ export const ru = {
     repositoryList: {
       title: 'Репозитории',
     },
-    followerList: {
+    followers: {
       title: 'Подписчики',
+      text: 'Подписчиков',
+      followsYou: 'Подписан на вас',
     },
-    followingList: {
+    following: {
       title: 'Подписки',
-    },
-    followYou: {
-      title: 'Подписан на вас',
+      text: 'Подписок',
+      followingYou: 'Подписан',
     },
   },
   repository: {
@@ -299,8 +300,6 @@ export const ru = {
     email: 'Электронная почта',
     website: 'Сайт',
     repositories: 'Репозиториев',
-    followers: 'Подписчиков',
-    following: 'Подписан',
     pullRequest: 'pull-запрос',
     issue: 'задача',
     cancel: 'Отменить',

--- a/src/locale/languages/tr.js
+++ b/src/locale/languages/tr.js
@@ -154,14 +154,15 @@ export const tr = {
     repositoryList: {
       title: "Repository'ler",
     },
-    followerList: {
+    followers: {
       title: 'Takipçiler',
+      text: 'Takipçiler',
+      followsYou: 'Seni takip ediyor',
     },
-    followingList: {
+    following: {
       title: 'Takip',
-    },
-    followYou: {
-      title: 'Seni takip ediyor',
+      text: 'Takip',
+      followingYou: 'Takip',
     },
   },
   repository: {
@@ -299,8 +300,6 @@ export const tr = {
     email: 'Email',
     website: 'Website',
     repositories: "Repository'ler",
-    followers: 'Takipçiler',
-    following: 'Takip',
     cancel: 'Vazgeç',
     yes: 'Evet',
     ok: 'TAMAM',


### PR DESCRIPTION
The fact is that for the Russian language Following as an action means another word, so you need an extension of the localization (`followingYou`). 

And earlier we had in the blocks of the count of followers and following did not take into account the declension, so I added it. Although you may notice duplication in other languages, but now it is more flexible to translate.

Also within PR, the message has been moved to a single namespace, for greater clarity.