### PR TITLE
fix(user-options): make height language item equal

### DIFF
--- a/src/auth/screens/user-options.screen.js
+++ b/src/auth/screens/user-options.screen.js
@@ -67,6 +67,13 @@ const styles = StyleSheet.create({
     paddingRight: 7,
     color: colors.black, // random any color for the correct display emoji
   },
+  containerStyle: {
+    paddingTop: 0,
+    paddingBottom: 0,
+    height: 45,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
 });
 
 const updateText = lang => ({
@@ -167,6 +174,7 @@ class UserOptions extends Component {
                       </View>
                     }
                     titleStyle={styles.listTitle}
+                    containerStyle={styles.containerStyle}
                     hideChevron={language !== item.code}
                     rightIcon={{ name: 'check' }}
                     onPress={() => changeLanguage(item.code)}


### PR DESCRIPTION
At the moment the language element has different height: when inactive and active, it can be seen in the screenshot, this PR makes the same height for any state.

| Before | After
| - | -
| <img src="https://user-images.githubusercontent.com/4408379/30930108-475dd4f8-a3c9-11e7-9ef3-304ca0025b9b.png" width="300" /> | <img src="https://user-images.githubusercontent.com/4408379/30930117-4a9fc022-a3c9-11e7-91ec-c4e3347e2442.png" width="300" /> 

