### PR TITLE
fix(api): get diff from API instead of web

### DIFF
--- a/src/issue/issue.action.js
+++ b/src/issue/issue.action.js
@@ -72,7 +72,7 @@ const getPullRequestDetails = issue => {
   return (dispatch, getState) => {
     const repoFullName = getState().repository.repository.full_name;
 
-    dispatch(getDiff(issue.pull_request.diff_url));
+    dispatch(getDiff(issue.pull_request.url));
     dispatch(getMergeStatus(repoFullName, issue.number));
   };
 };


### PR DESCRIPTION
Noticed this error while using Reactotron: 

`GET https://api.github.com/://github.com/gitpoint/git-point/pull/378.diff`

The problem was that `fetchDiff()` was called with `diff_url` from this struct:
<img width="542" alt="screen shot 2017-09-28 at 2 55 25 pm" src="https://user-images.githubusercontent.com/304450/30970475-7f88650e-a465-11e7-9090-4d6f1d06763f.png">

which is outside the API, causing an error in `v3.call` while checking the presence of the API root.

Fixed by using `pull_request.url` that returns a diff when called with the `application/vnd.github.v3.diff+json` accept header
