### PR TITLE
fix(ux): Fix a typo with tiny adjustment

### DIFF
--- a/src/components/repository-list-item.component.js
+++ b/src/components/repository-list-item.component.js
@@ -75,7 +75,7 @@ const renderTitle = repository =>
       <Icon
         containerStyle={styles.extraInfoIcon}
         name="star"
-        type="octicion"
+        type="octicon"
         size={15}
         color={colors.greyDark}
       />
@@ -93,7 +93,7 @@ const renderTitle = repository =>
       />
 
       <Text
-        style={[styles.extraInfoSubject, { paddingLeft: 0, marginLeft: -2 }]}
+        style={[styles.extraInfoSubject, { paddingLeft: 0, marginRight: 13 }]}
       >
         {abbreviateNumber(repository.forks_count)}
       </Text>


### PR DESCRIPTION
- before:

<img width="320" alt="2017-09-30 15 33 37" src="https://user-images.githubusercontent.com/1736154/31043840-a42bf812-a5f5-11e7-8fbc-5517b2b6f1fd.png">

- after:

<img width="319" alt="2017-09-30 15 30 38" src="https://user-images.githubusercontent.com/1736154/31043845-af2a3bfc-a5f5-11e7-97a0-b1ded820c8fa.png">

Some hints:
- Original layout: starIcon-3-starCount-15-forkIcon-(-2)-forkCount-15-langIcon-3-langStr-15
- The 3 icons share the same width, which is 15, but:
   - I don't know why forkIcon is left aligned, while the other 2 are center aligned
- Then,
   - the space between forkIcon and forkCount is too narrow
   - the space between starCount and langIcon is too wide
- So I adjust the layout to: starIcon-3-starCount-15-forkIcon-0-forkCount-13-langIcon-3-langStr-15

Please review or merge as you wish. I don't want this tiny PR bothers the v1.3 release.