### PR TITLE
fix(api): Run getRepositoryFile() through API, not raw.githubcontents

### DIFF
--- a/src/repository/screens/repository-file.screen.js
+++ b/src/repository/screens/repository-file.screen.js
@@ -101,7 +101,7 @@ class RepositoryFile extends Component {
     const fileType = content.name.split('.').pop();
 
     if (!this.isImage(fileType)) {
-      this.props.getRepositoryFile(content.download_url);
+      this.props.getRepositoryFile(content.url);
     } else {
       this.setImageSize(content.download_url);
     }


### PR DESCRIPTION
Since the API change from #361, file source code fetching have not been working. 

The problem was calling `.download_url` which points to a raw file on `raw.githubcontents.com` instead of `.url` which holds a proper API url.