### PR TITLE
style(notification-badge): Extend badge props + Refactor style

### DIFF
--- a/src/components/badge.component.js
+++ b/src/components/badge.component.js
@@ -1,38 +1,45 @@
 import React from 'react';
 import { StyleSheet, View, Text } from 'react-native';
 
-import { colors, fonts } from 'config';
+import { fonts, normalize } from 'config';
 
 type Props = {
+  color: string,
+  backgroundColor: string,
   text: string,
+  largeText: boolean,
 };
 
 const styles = StyleSheet.create({
   badge: {
-    position: 'absolute',
-    right: 1,
-    top: -1,
-    backgroundColor: colors.darkerRed,
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
     borderRadius: 18,
     width: 18,
     height: 18,
-    justifyContent: 'center',
-    alignItems: 'center',
-    borderColor: colors.alabaster,
-    borderWidth: 1,
   },
   badgeText: {
-    alignSelf: 'center',
-    fontSize: 9,
-    ...fonts.fontPrimary,
-    color: colors.white,
+    ...fonts.fontPrimaryBold,
     backgroundColor: 'transparent',
+  },
+  textSmall: {
+    fontSize: normalize(8),
+  },
+  textLarge: {
+    fontSize: normalize(9.5),
   },
 });
 
-export const Badge = ({ text }: Props) =>
-  <View style={styles.badge}>
-    <Text style={styles.badgeText}>
+export const Badge = ({ color, backgroundColor, text, largeText }: Props) =>
+  <View style={StyleSheet.flatten([styles.badge, { backgroundColor }])}>
+    <Text
+      style={[
+        styles.badgeText,
+        largeText ? styles.textLarge : styles.textSmall,
+        { color },
+      ]}
+    >
       {text}
     </Text>
   </View>;

--- a/src/components/badge.component.js
+++ b/src/components/badge.component.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { StyleSheet, View, Text } from 'react-native';
 
-import { fonts, normalize } from 'config';
+import { colors, fonts, normalize } from 'config';
 
 type Props = {
   color: string,
@@ -18,13 +18,15 @@ const styles = StyleSheet.create({
     borderRadius: 18,
     width: 18,
     height: 18,
+    borderColor: colors.alabaster,
+    borderWidth: 1,
   },
   badgeText: {
     ...fonts.fontPrimaryBold,
     backgroundColor: 'transparent',
   },
   textSmall: {
-    fontSize: normalize(8),
+    fontSize: normalize(7),
   },
   textLarge: {
     fontSize: normalize(9.5),

--- a/src/components/notification-icon.component.js
+++ b/src/components/notification-icon.component.js
@@ -1,10 +1,24 @@
 // @flow
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { View } from 'react-native';
+import { View, StyleSheet } from 'react-native';
 import { Icon } from 'react-native-elements';
 
 import { Badge } from 'components';
+
+import { colors } from 'config';
+
+const styles = StyleSheet.create({
+  icon: {
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  badgeContainer: {
+    position: 'absolute',
+    right: 0,
+    top: 0,
+  },
+});
 
 const mapStateToProps = state => ({
   notificationsCount: state.notifications.notificationsCount,
@@ -13,7 +27,7 @@ const mapStateToProps = state => ({
 class NotificationIconComponent extends Component {
   props: {
     iconColor: string,
-    notificationsCount: string,
+    notificationsCount: number,
   };
 
   render() {
@@ -22,14 +36,21 @@ class NotificationIconComponent extends Component {
     return (
       <View>
         <Icon
-          containerStyle={{ justifyContent: 'center', alignItems: 'center' }}
+          containerStyle={styles.icon}
           color={iconColor}
           name="notifications"
           size={33}
         />
 
         {!!notificationsCount &&
-          <Badge text={notificationsCount > 99 ? '99+' : notificationsCount} />}
+          <View style={styles.badgeContainer}>
+            <Badge
+              color={colors.white}
+              backgroundColor={colors.blue}
+              text={notificationsCount > 99 ? '99+' : notificationsCount}
+              largeText={notificationsCount <= 99}
+            />
+          </View>}
       </View>
     );
   }

--- a/src/components/notification-icon.component.js
+++ b/src/components/notification-icon.component.js
@@ -9,14 +9,10 @@ import { Badge } from 'components';
 import { colors } from 'config';
 
 const styles = StyleSheet.create({
-  icon: {
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
   badgeContainer: {
     position: 'absolute',
-    right: 0,
-    top: 0,
+    right: -1,
+    top: -1,
   },
 });
 
@@ -35,18 +31,13 @@ class NotificationIconComponent extends Component {
 
     return (
       <View>
-        <Icon
-          containerStyle={styles.icon}
-          color={iconColor}
-          name="notifications"
-          size={33}
-        />
+        <Icon color={iconColor} name="notifications" size={33} />
 
         {!!notificationsCount &&
           <View style={styles.badgeContainer}>
             <Badge
               color={colors.white}
-              backgroundColor={colors.blue}
+              backgroundColor={colors.darkerRed}
               text={notificationsCount > 99 ? '99+' : notificationsCount}
               largeText={notificationsCount <= 99}
             />


### PR DESCRIPTION
Update notifications icon badge:

1. Made it blue and text more prominent
2. Moved the `absolute` style logic to outside the badge component. If we plan on using this component elsewhere it shouldn't have absolute styling within
3. Extended props to include color and background color

CC @lex111 

![screen shot 2017-09-30 at 11 29 28 pm](https://user-images.githubusercontent.com/12476932/31051546-f66eaadc-a638-11e7-81af-4c4a4b89f383.png)
