### PR TITLE
fix(md): Display a link instead of the image inside a <li>

### DIFF
--- a/src/components/github-htmlview.component.js
+++ b/src/components/github-htmlview.component.js
@@ -132,6 +132,18 @@ const cellForNode = node =>
     ? CellWithImage
     : Cell;
 
+const hasAncestor = (node, ancestorName) => {
+  if (node.parent === null) {
+    return false;
+  }
+
+  if (node.parent.type === 'tag' && node.parent.name === ancestorName) {
+    return true;
+  }
+
+  return hasAncestor(node.parent, ancestorName);
+};
+
 const onlyTagsChildren = node =>
   node.children.filter(elem => elem.type === 'tag');
 
@@ -238,8 +250,20 @@ export class GithubHtmlView extends Component {
         hr: (node, index, siblings, parent, defaultRenderer) =>
           <View key={index} style={{ ...hrStyle }} />,
         img: (node, index, siblings, parent, defaultRenderer) => {
-          const zoom =
-            parent && parent.type === 'tag' && parent.name === 'td' ? 0.3 : 0.6;
+          if (hasAncestor(node, 'li')) {
+            return (
+              <Text
+                style={linkStyle}
+                onPress={() =>
+                  onLinkPress({ ...node, attribs: { href: node.attribs.src } })}
+              >
+                [{node.attribs.alt}]
+                {'\n'}
+              </Text>
+            );
+          }
+
+          const zoom = hasAncestor(node, 'table') ? 0.3 : 0.6;
 
           return (
             <ImageZoom


### PR DESCRIPTION
There was a nested View in Text when a `<img>` tag was used inside a `<li>` element (spotted on Antoine's comment in #381 )

Fixed by displaying the `alt` attribute of the image as a clickable text, opening the image with Linking for now:

![screen shot 2017-10-01 at 8 06 21 pm](https://user-images.githubusercontent.com/304450/31057992-676a85a4-a6ec-11e7-8eff-99ce9646116f.png)
