### PR TITLE
fix(*): Style updates, add edit issue body functionality

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -260,10 +260,9 @@ export const fetchEditIssue = (
   repoName,
   issueNum,
   editParams,
-  updateParams,
   accessToken
 ) =>
-  v3.patch(
+  v3.patchFull(
     `/repos/${owner}/${repoName}/issues/${issueNum}`,
     accessToken,
     editParams

--- a/src/components/button.component.js
+++ b/src/components/button.component.js
@@ -9,6 +9,9 @@ const types = {
       borderColor: '#adadad',
       backgroundColor: '#e6e6e6',
     },
+    iconStyle: {
+      color: '#333333',
+    },
     textStyle: {
       color: '#333333',
     },
@@ -188,7 +191,12 @@ export class Button extends Component {
         }}
         disabledStyle={disabledStyle}
         icon={
-          icon && { ...defaultIconStyle, ...sizes[size].iconStyle, ...icon }
+          icon && {
+            ...defaultIconStyle,
+            ...types[type].iconStyle,
+            ...sizes[size].iconStyle,
+            ...icon,
+          }
         }
       />
     );

--- a/src/components/issue-list-item.component.js
+++ b/src/components/issue-list-item.component.js
@@ -61,7 +61,7 @@ const getIconName = (type, issue) => {
   return 'git-pull-request';
 };
 
-export const IssueListItem = ({ type, issue, navigation, language }: Props) => (
+export const IssueListItem = ({ type, issue, navigation, language }: Props) =>
   <TouchableHighlight
     style={issue.state === 'closed' && styles.closedIssue}
     onPress={() =>
@@ -101,8 +101,9 @@ export const IssueListItem = ({ type, issue, navigation, language }: Props) => (
       />
       <View style={styles.commentsContainer}>
         <Icon name="comment" type="octicon" size={18} color={colors.grey} />
-        <Text style={styles.comments}>{issue.comments}</Text>
+        <Text style={styles.comments}>
+          {issue.comments}
+        </Text>
       </View>
     </View>
-  </TouchableHighlight>
-);
+  </TouchableHighlight>;

--- a/src/components/repository-list-item.component.js
+++ b/src/components/repository-list-item.component.js
@@ -61,7 +61,7 @@ const renderTitle = (repository, showFullName) =>
         {repository.private &&
           <View style={styles.privateIconContainer}>
             <Icon
-              size={20}
+              size={16}
               name="lock"
               type="octicon"
               color={colors.greyDarkest}

--- a/src/components/repository-list-item.component.js
+++ b/src/components/repository-list-item.component.js
@@ -7,6 +7,7 @@ import { colors, languageColors, fonts, normalize } from 'config';
 
 type Props = {
   repository: Object,
+  showFullName: boolean,
   navigation: Object,
 };
 
@@ -18,22 +19,14 @@ const styles = StyleSheet.create({
   },
   titleWrapper: {
     flexDirection: 'row',
+    alignItems: 'center',
   },
   title: {
     color: colors.primaryDark,
     ...fonts.fontPrimarySemiBold,
   },
-  private: {
-    borderColor: 'rgba(27, 31, 35, 0.15)',
-    borderRadius: 2,
-    borderStyle: 'solid',
-    borderWidth: 1,
-    color: colors.greyDark,
-    fontSize: normalize(10),
-    marginLeft: 8,
-    paddingLeft: 4,
-    paddingRight: 2,
-    paddingTop: 2,
+  privateIconContainer: {
+    marginLeft: 6,
   },
   description: {
     color: colors.primaryDark,
@@ -58,14 +51,22 @@ const styles = StyleSheet.create({
   },
 });
 
-const renderTitle = repository =>
+const renderTitle = (repository, showFullName) =>
   <View style={styles.wrapper}>
     <View style={styles.repositoryContainer}>
       <View style={styles.titleWrapper}>
         <Text style={styles.title}>
-          {repository.name}
+          {showFullName ? repository.full_name : repository.name}
         </Text>
-        {repository.private && <Text style={styles.private}>Private</Text>}
+        {repository.private &&
+          <View style={styles.privateIconContainer}>
+            <Icon
+              size={20}
+              name="lock"
+              type="octicon"
+              color={colors.greyDarkest}
+            />
+          </View>}
       </View>
       <Text style={styles.description}>
         {emojifyText(repository.description)}
@@ -112,10 +113,14 @@ const renderTitle = repository =>
     </View>
   </View>;
 
-export const RepositoryListItem = ({ repository, navigation }: Props) =>
+export const RepositoryListItem = ({
+  repository,
+  showFullName,
+  navigation,
+}: Props) =>
   <ListItem
     key={repository.id}
-    title={renderTitle(repository)}
+    title={renderTitle(repository, showFullName)}
     titleStyle={styles.title}
     rightIcon={{
       name: repository.fork ? 'repo-forked' : 'repo',
@@ -125,3 +130,7 @@ export const RepositoryListItem = ({ repository, navigation }: Props) =>
     underlayColor={colors.greyLight}
     onPress={() => navigation.navigate('Repository', { repository })}
   />;
+
+RepositoryListItem.defaultProps = {
+  showFullName: true,
+};

--- a/src/components/repository-list-item.component.js
+++ b/src/components/repository-list-item.component.js
@@ -63,7 +63,7 @@ const renderTitle = repository =>
     <View style={styles.repositoryContainer}>
       <View style={styles.titleWrapper}>
         <Text style={styles.title}>
-          {repository.full_name}
+          {repository.name}
         </Text>
         {repository.private && <Text style={styles.private}>Private</Text>}
       </View>

--- a/src/issue/issue.action.js
+++ b/src/issue/issue.action.js
@@ -13,6 +13,7 @@ import {
   GET_ISSUE_COMMENTS,
   POST_ISSUE_COMMENT,
   EDIT_ISSUE,
+  EDIT_ISSUE_BODY,
   CHANGE_LOCK_STATUS,
   GET_ISSUE_DIFF,
   GET_ISSUE_MERGE_STATUS,
@@ -172,6 +173,28 @@ export const editIssueComment = (issueCommentId, owner, repoName, body) => {
   };
 };
 
+export const editIssueBody = (owner, repoName, issueNum, body) => {
+  return (dispatch, getState) => {
+    const accessToken = getState().auth.accessToken;
+
+    dispatch({ type: EDIT_ISSUE_BODY.PENDING });
+
+    return fetchEditIssue(owner, repoName, issueNum, { body }, accessToken)
+      .then(data => {
+        dispatch({
+          type: EDIT_ISSUE_BODY.SUCCESS,
+          payload: data,
+        });
+      })
+      .catch(error => {
+        dispatch({
+          type: EDIT_ISSUE_BODY.ERROR,
+          payload: error,
+        });
+      });
+  };
+};
+
 export const editIssue = (
   owner,
   repoName,
@@ -184,14 +207,7 @@ export const editIssue = (
 
     dispatch({ type: EDIT_ISSUE.PENDING });
 
-    return fetchEditIssue(
-      owner,
-      repoName,
-      issueNum,
-      editParams,
-      updateParams,
-      accessToken
-    )
+    return fetchEditIssue(owner, repoName, issueNum, editParams, accessToken)
       .then(() => {
         dispatch({
           type: EDIT_ISSUE.SUCCESS,
@@ -246,17 +262,15 @@ export const getIssueFromUrl = url => {
     dispatch({ type: GET_ISSUE_FROM_URL.PENDING });
 
     return v3
-      .getHtml(url, accessToken)
+      .getFull(url, accessToken)
       .then(issue => {
-        const parsedIssue = JSON.parse(issue);
-
         dispatch({
           type: GET_ISSUE_FROM_URL.SUCCESS,
-          payload: parsedIssue,
+          payload: issue,
         });
 
-        if (parsedIssue.pull_request) {
-          dispatch(getPullRequestDetails(parsedIssue));
+        if (issue.pull_request) {
+          dispatch(getPullRequestDetails(issue));
         }
       })
       .catch(error => {

--- a/src/issue/issue.reducer.js
+++ b/src/issue/issue.reducer.js
@@ -4,6 +4,7 @@ import {
   DELETE_ISSUE_COMMENT,
   EDIT_ISSUE_COMMENT,
   EDIT_ISSUE,
+  EDIT_ISSUE_BODY,
   CHANGE_LOCK_STATUS,
   GET_ISSUE_DIFF,
   GET_ISSUE_MERGE_STATUS,
@@ -129,6 +130,28 @@ export const issueReducer = (state = initialState, action = {}) => {
         ...state,
         error: action.payload,
         isEditingIssue: false,
+      };
+    case EDIT_ISSUE_BODY.PENDING:
+      return {
+        ...state,
+        isEditingComment: true,
+      };
+    case EDIT_ISSUE_BODY.SUCCESS: {
+      return {
+        ...state,
+        issue: {
+          ...state.issue,
+          body: action.payload.body,
+          body_html: action.payload.body_html,
+        },
+        isEditingComment: false,
+      };
+    }
+    case EDIT_ISSUE_BODY.ERROR:
+      return {
+        ...state,
+        error: action.payload,
+        isEditingComment: false,
       };
     case CHANGE_LOCK_STATUS.PENDING:
       return {

--- a/src/issue/issue.type.js
+++ b/src/issue/issue.type.js
@@ -5,6 +5,7 @@ export const DELETE_ISSUE_COMMENT = createActionSet('DELETE_ISSUE_COMMENT');
 export const EDIT_ISSUE_COMMENT = createActionSet('EDIT_ISSUE_COMMENT');
 export const POST_ISSUE_COMMENT = createActionSet('POST_ISSUE_COMMENT');
 export const EDIT_ISSUE = createActionSet('EDIT_ISSUE');
+export const EDIT_ISSUE_BODY = createActionSet('EDIT_ISSUE_BODY');
 export const CHANGE_LOCK_STATUS = createActionSet('CHANGE_LOCK_STATUS');
 export const GET_ISSUE_DIFF = createActionSet('GET_ISSUE_DIFF');
 export const GET_ISSUE_MERGE_STATUS = createActionSet('GET_ISSUE_MERGE_STATUS');

--- a/src/issue/screens/edit-issue-comment.screen.js
+++ b/src/issue/screens/edit-issue-comment.screen.js
@@ -14,7 +14,7 @@ import { ListItem } from 'react-native-elements';
 import { ViewContainer, SectionList, LoadingModal } from 'components';
 import { translate } from 'utils';
 import { colors, fonts, normalize } from 'config';
-import { editIssueComment } from '../issue.action';
+import { editIssueBody, editIssueComment } from '../issue.action';
 
 const styles = StyleSheet.create({
   textInput: {
@@ -42,6 +42,7 @@ const styles = StyleSheet.create({
 
 const mapStateToProps = state => ({
   language: state.auth.language,
+  issue: state.issue.issue,
   repository: state.repository.repository,
   isEditingComment: state.issue.isEditingComment,
 });
@@ -49,6 +50,7 @@ const mapStateToProps = state => ({
 const mapDispatchToProps = dispatch =>
   bindActionCreators(
     {
+      editIssueBody,
       editIssueComment,
     },
     dispatch
@@ -56,10 +58,12 @@ const mapDispatchToProps = dispatch =>
 
 class EditIssueComment extends Component {
   props: {
+    editIssueBody: Function,
     editIssueComment: Function,
     language: string,
     repository: Object,
     navigation: Object,
+    issue: Object,
     isEditingComment: boolean,
   };
 
@@ -77,17 +81,18 @@ class EditIssueComment extends Component {
     };
   }
 
-  editIssueComment = () => {
-    const { navigation } = this.props;
+  editComment = () => {
+    const { issue, navigation } = this.props;
     const { repository, comment } = this.props.navigation.state.params;
 
     const repoName = repository.name;
     const owner = repository.owner.login;
     const text = this.state.issueComment;
+    const action = comment.repository_url
+      ? this.props.editIssueBody(owner, repoName, issue.number, text)
+      : this.props.editIssueComment(comment.id, owner, repoName, text);
 
-    this.props
-      .editIssueComment(comment.id, owner, repoName, text)
-      .then(() => navigation.goBack());
+    action.then(() => navigation.goBack());
   };
 
   render() {
@@ -123,7 +128,7 @@ class EditIssueComment extends Component {
                 hideChevron
                 underlayColor={colors.greyLight}
                 titleStyle={styles.submitTitle}
-                onPress={() => this.editIssueComment()}
+                onPress={this.editComment}
               />
             </View>
           </SectionList>

--- a/src/notifications/screens/notifications.screen.js
+++ b/src/notifications/screens/notifications.screen.js
@@ -58,7 +58,7 @@ const mapDispatchToProps = dispatch =>
       getNotificationsCount,
       markAllNotificationsAsRead,
     },
-    dispatch
+    dispatch,
   );
 
 const styles = StyleSheet.create({
@@ -119,6 +119,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   noneTitle: {
+    paddingHorizontal: 15,
     fontSize: normalize(16),
     textAlign: 'center',
     ...fonts.fontPrimary,
@@ -188,7 +189,7 @@ class Notifications extends Component {
 
   getImage(repoName) {
     const notificationForRepo = this.notifications().find(
-      notification => notification.repository.full_name === repoName
+      notification => notification.repository.full_name === repoName,
     );
 
     return notificationForRepo.repository.owner.avatar_url;
@@ -225,8 +226,8 @@ class Notifications extends Component {
     const repositories = [
       ...new Set(
         this.notifications().map(
-          notification => notification.repository.full_name
-        )
+          notification => notification.repository.full_name,
+        ),
       ),
     ];
 
@@ -360,7 +361,7 @@ class Notifications extends Component {
     } = this.props;
     const { type } = this.state;
     const notifications = this.notifications().filter(
-      notification => notification.repository.full_name === item
+      notification => notification.repository.full_name === item,
     );
     const isFirstItem = this.getSortedRepos().indexOf(item) === 0;
     const isFirstTab = type === 0;
@@ -415,7 +416,7 @@ class Notifications extends Component {
                 iconAction={notificationID => markAsRead(notificationID)}
                 navigationAction={notify => this.navigateToThread(notify)}
                 navigation={this.props.navigation}
-              />
+              />,
             )}
           </ScrollView>
         </Card>
@@ -463,7 +464,7 @@ class Notifications extends Component {
                   animating={isRetrievingNotifications}
                   text={translate(
                     'notifications.main.retrievingMessage',
-                    language
+                    language,
                   )}
                   style={styles.marginSpacing}
                   center
@@ -503,5 +504,5 @@ class Notifications extends Component {
 }
 
 export const NotificationsScreen = connect(mapStateToProps, mapDispatchToProps)(
-  Notifications
+  Notifications,
 );

--- a/src/notifications/screens/notifications.screen.js
+++ b/src/notifications/screens/notifications.screen.js
@@ -119,7 +119,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   noneTitle: {
-    paddingHorizontal: 35,
     fontSize: normalize(16),
     textAlign: 'center',
     ...fonts.fontPrimary,

--- a/src/notifications/screens/notifications.screen.js
+++ b/src/notifications/screens/notifications.screen.js
@@ -13,10 +13,11 @@ import {
   Image,
   Platform,
 } from 'react-native';
-import { ButtonGroup, Card, Icon, Button } from 'react-native-elements';
+import { ButtonGroup, Card, Icon } from 'react-native-elements';
 
 import { v3 } from 'api';
 import {
+  Button,
   ViewContainer,
   LoadingContainer,
   NotificationListItem,
@@ -118,18 +119,15 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   noneTitle: {
+    paddingHorizontal: 35,
     fontSize: normalize(16),
     textAlign: 'center',
     ...fonts.fontPrimary,
   },
-  markAllAsReadButton: {
-    marginVertical: 15,
+  markAllAsReadButtonContainer: {
     marginTop: 0,
     marginBottom: 20,
-    paddingVertical: 3,
-    borderColor: colors.greyMid,
-    borderWidth: 1,
-    borderRadius: 3,
+    marginHorizontal: 10,
   },
   contentBlock: {
     flex: 1,
@@ -372,20 +370,14 @@ class Notifications extends Component {
       <View>
         {isFirstItem &&
           isFirstTab &&
-          <Button
-            icon={{
-              name: 'check',
-              size: 20,
-              type: 'octicon',
-              color: colors.black,
-            }}
-            title={translate('notifications.main.markAllAsRead')}
-            buttonStyle={styles.markAllAsReadButton}
-            color={colors.black}
-            backgroundColor={colors.white}
-            textStyle={styles.buttonGroupText}
-            onPress={() => markAllNotificationsAsRead()}
-          />}
+          <View style={styles.markAllAsReadButtonContainer}>
+            <Button
+              type="success"
+              icon={{ name: 'check', type: 'octicon' }}
+              onPress={() => markAllNotificationsAsRead()}
+              title={translate('notifications.main.markAllAsRead')}
+            />
+          </View>}
 
         <Card containerStyle={styles.repositoryContainer}>
           <View style={styles.headerContainer}>

--- a/src/user/screens/repository-list.screen.js
+++ b/src/user/screens/repository-list.screen.js
@@ -14,6 +14,7 @@ import { colors } from 'config';
 import { getRepositories, searchUserRepos } from 'user';
 
 const mapStateToProps = state => ({
+  authUser: state.auth.user,
   user: state.user.user,
   repositories: state.user.repositories,
   searchedUserRepos: state.user.searchedUserRepos,
@@ -27,7 +28,7 @@ const mapDispatchToProps = dispatch =>
       getRepositories,
       searchUserRepos,
     },
-    dispatch
+    dispatch,
   );
 
 const styles = StyleSheet.create({
@@ -55,6 +56,7 @@ class RepositoryList extends Component {
   props: {
     getRepositories: Function,
     searchUserRepos: Function,
+    authUser: Object,
     user: Object,
     repositories: Array,
     searchedUserRepos: Array,
@@ -115,6 +117,7 @@ class RepositoryList extends Component {
 
   render() {
     const {
+      authUser,
       isPendingRepositories,
       isPendingSearchUserRepos,
       navigation,
@@ -149,7 +152,7 @@ class RepositoryList extends Component {
 
           {loading &&
             [...Array(searchStart ? repoCount : 10)].map(
-              (item, index) => <LoadingRepositoryListItem key={index} /> // eslint-disable-line react/no-array-index-key
+              (item, index) => <LoadingRepositoryListItem key={index} />, // eslint-disable-line react/no-array-index-key
             )}
 
           {!loading &&
@@ -161,6 +164,7 @@ class RepositoryList extends Component {
                 renderItem={({ item }) =>
                   <RepositoryListItem
                     repository={item}
+                    showFullName={authUser.login !== item.owner.login}
                     navigation={navigation}
                   />}
               />
@@ -173,5 +177,5 @@ class RepositoryList extends Component {
 
 export const RepositoryListScreen = connect(
   mapStateToProps,
-  mapDispatchToProps
+  mapDispatchToProps,
 )(RepositoryList);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1888,7 +1888,7 @@ dateformat@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-2.0.0.tgz#2743e3abb5c3fc2462e527dca445e04e9f4dee17"
 
-debug@2, debug@2.6.8, debug@^2.1.1, debug@^2.2.0, debug@^2.6.3, debug@^2.6.8:
+debug@2, debug@2.6.8, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0, debug@^2.6.3, debug@^2.6.8:
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
   dependencies:
@@ -1905,12 +1905,6 @@ debug@2.3.3:
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.3.3.tgz#40c453e67e6e13c901ddec317af8986cda9eff8c"
   dependencies:
     ms "0.7.2"
-
-debug@^2.1.3:
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
-  dependencies:
-    ms "2.0.0"
 
 decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
@@ -5363,15 +5357,7 @@ react-native-table-component@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/react-native-table-component/-/react-native-table-component-1.0.5.tgz#84e91f50e92f3cf35eb224749d28444244aced80"
 
-react-native-vector-icons@^4.2.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/react-native-vector-icons/-/react-native-vector-icons-4.3.0.tgz#49eab845fbcde6354cb3dbcb62c1abd1f6abc866"
-  dependencies:
-    lodash "^4.0.0"
-    prop-types "^15.5.10"
-    yargs "^8.0.2"
-
-react-native-vector-icons@^4.4.0:
+react-native-vector-icons@^4.2.0, react-native-vector-icons@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/react-native-vector-icons/-/react-native-vector-icons-4.4.0.tgz#cdfc1cd86ab495b2a4926bcec8f08c155475cbf1"
   dependencies:


### PR DESCRIPTION
Various fixes/updates for #381 

- Changes color of mark all notifications button

![image](https://user-images.githubusercontent.com/12476932/31062274-5bf9f83e-a6f7-11e7-86e0-b0179f43042f.png)

- Adds padding for no notifications message in notifications screen

![image](https://user-images.githubusercontent.com/12476932/31062279-7226bcc8-a6f7-11e7-901e-61f90f9b9479.png)

- Fixes this problem:

![image](https://user-images.githubusercontent.com/12476932/31062288-854ac254-a6f7-11e7-8881-fa1158362f4d.png)

- Allows editing of issue description

![editdescription](https://user-images.githubusercontent.com/12476932/31062297-9a0ee760-a6f7-11e7-996e-717d74c1dca9.gif)

- Makes title/subtitle of `IssueDescriptionListItem` better in terms of boldness

![image](https://user-images.githubusercontent.com/12476932/31062315-b9ef6262-a6f7-11e7-8f6e-cf695645f2fa.png)

- Removes the user title from repository list item (@lex111 - with this it's unlikely we'll see the `private` box being squeezed anymore as most repo titles aren't nearly as long)

![image](https://user-images.githubusercontent.com/12476932/31062366-2ae03046-a6f8-11e7-996a-e1cdb2ff2507.png)
 