### PR TITLE
fix(events): update screen after change language

### DIFF
--- a/src/auth/screens/events.screen.js
+++ b/src/auth/screens/events.screen.js
@@ -569,6 +569,7 @@ class Events extends Component {
                   </Text>
                 </View>}
             </View>}
+          extraData={this.props.language}
         />
       );
     }


### PR DESCRIPTION
@housseindjirdeh [wrote](https://github.com/gitpoint/git-point/issues/381#issuecomment-333349250) that the screen of events is not updated after changing the language. This PR fixes this, I completely forgot about `extraData` from `FlatList`, which is  needed for similar purposes :confused: 