### PR TITLE
refactor(profiles): show user data when it is fully loaded

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,5 +1,3 @@
-import { abbreviateNumber } from 'utils';
-
 // These keys are for development purposes and do not represent the actual application keys.
 // Feel free to use them or use a new set of keys by creating an OAuth application of your own.
 // https://github.com/settings/applications/new
@@ -56,7 +54,7 @@ export const v3 = {
 
     return params;
   },
-  count: async (url, accessToken, abbreviate = false) => {
+  count: async (url, accessToken) => {
     const finalUrl =
       url.indexOf('?') !== -1 ? `${url}&per_page=1` : `${url}?per_page=1`;
     const response = await v3.get(finalUrl, accessToken);
@@ -77,7 +75,7 @@ export const v3 = {
       });
     }
 
-    return abbreviate ? abbreviateNumber(number) : number;
+    return number;
   },
   delete: async (url, accessToken) => {
     const response = await v3.call(
@@ -306,7 +304,7 @@ export const fetchForkRepo = (owner, repo, accessToken) =>
   v3.post(`/repos/${owner}/${repo}/forks`, accessToken);
 
 export const fetchStarCount = (owner, accessToken) =>
-  v3.count(`/users/${owner}/starred`, accessToken, true);
+  v3.count(`/users/${owner}/starred`, accessToken);
 
 export const isWatchingRepo = (url, accessToken) => v3.head(url, accessToken);
 

--- a/src/auth/screens/auth-profile.screen.js
+++ b/src/auth/screens/auth-profile.screen.js
@@ -121,9 +121,9 @@ class AuthProfile extends Component {
           renderContent={() =>
             <UserProfile
               type="user"
-              initialUser={hasInitialUser ? user : {}}
-              user={hasInitialUser ? user : {}}
-              starCount={hasInitialUser ? starCount : ''}
+              initialUser={hasInitialUser && !!starCount ? user : {}}
+              user={hasInitialUser && !!starCount ? user : {}}
+              starCount={hasInitialUser && !!starCount ? starCount : ''}
               language={language}
               navigation={navigation}
             />}

--- a/src/components/user-profile.component.js
+++ b/src/components/user-profile.component.js
@@ -1,7 +1,8 @@
+/* eslint-disable no-prototype-builtins */
 import React from 'react';
 import { StyleSheet, Text, View, TouchableOpacity } from 'react-native';
 import { colors, fonts, normalize } from 'config';
-import { translate } from 'utils';
+import { translate, abbreviateNumber } from 'utils';
 import { ImageZoom } from 'components';
 
 type Props = {
@@ -124,6 +125,7 @@ export const UserProfile = ({
       </Text>
     </View>
     <View style={styles.details}>
+      {user.hasOwnProperty('public_repos') &&
       <TouchableOpacity
         style={styles.unit}
         onPress={() =>
@@ -141,19 +143,19 @@ export const UserProfile = ({
         <Text style={styles.unitText}>
           {translate('common.repositories', language)}
         </Text>
-      </TouchableOpacity>
+      </TouchableOpacity>}
 
-      {type !== 'org' &&
+      {type !== 'org' && !isNaN(parseInt(starCount, 10)) &&
         <TouchableOpacity style={styles.unit}>
           <Text style={styles.unitNumber}>
-            {!isNaN(parseInt(starCount, 10)) ? starCount : ' '}
+            {abbreviateNumber(starCount)}
           </Text>
           <Text style={styles.unitText}>
             {translate('common.stars', language)}
           </Text>
         </TouchableOpacity>}
 
-      {type !== 'org' &&
+      {type !== 'org' && user.hasOwnProperty('followers') &&
         <TouchableOpacity
           style={styles.unit}
           onPress={() =>
@@ -175,7 +177,7 @@ export const UserProfile = ({
             </Text>}
         </TouchableOpacity>}
 
-      {type !== 'org' &&
+      {type !== 'org' && user.hasOwnProperty('following') &&
         <TouchableOpacity
           style={styles.unit}
           onPress={() =>

--- a/src/user/screens/profile.screen.js
+++ b/src/user/screens/profile.screen.js
@@ -150,19 +150,12 @@ class Profile extends Component {
     } = this.props;
     const { refreshing } = this.state;
     const initialUser = navigation.state.params.user;
-    const isPending = isPendingUser || isPendingOrgs;
+    const isPending = isPendingUser || isPendingOrgs || isPendingStarCount || isPendingCheckFollowing || isPendingCheckFollower;
     const userActions = [
       isFollowing
         ? translate('user.profile.unfollow', language)
         : translate('user.profile.follow', language),
     ];
-    const isAllDataLoaded =
-      initialUser.login === user.login &&
-      !(
-        isPendingStarCount ||
-        isPendingCheckFollowing ||
-        isPendingCheckFollower
-      );
 
     return (
       <ViewContainer>
@@ -171,10 +164,10 @@ class Profile extends Component {
             <UserProfile
               type="user"
               initialUser={initialUser}
-              starCount={isAllDataLoaded ? starCount : ''}
-              isFollowing={!isAllDataLoaded ? false : isFollowing}
-              isFollower={!isAllDataLoaded ? false : isFollower}
-              user={isAllDataLoaded ? user : {}}
+              starCount={!isPending ? starCount : ''}
+              isFollowing={!isPending ? isFollowing : false}
+              isFollower={!isPending ? isFollower : false}
+              user={!isPending ? user : {}}
               language={language}
               navigation={navigation}
             />}


### PR DESCRIPTION
This is a refactoring of refactoring :laughing:  Second attempt #366
In fact, in the past PR did not take into account the `auth profile`, and it was so that the block with the stars was displayed when there were none.

I need someone to check it, I need to know whether it's good now.