### PR TITLE
feat(issue): Disable merge button if not possible

### DIFF
--- a/src/components/issue-description.component.js
+++ b/src/components/issue-description.component.js
@@ -73,6 +73,7 @@ export class IssueDescription extends Component {
   props: {
     issue: Object,
     diff: string,
+    isMergeable: boolean,
     isMerged: boolean,
     isPendingDiff: boolean,
     isPendingCheckMerge: boolean,
@@ -92,6 +93,7 @@ export class IssueDescription extends Component {
     const {
       diff,
       issue,
+      isMergeable,
       isMerged,
       isPendingDiff,
       isPendingCheckMerge,
@@ -113,7 +115,7 @@ export class IssueDescription extends Component {
 
     return (
       <View style={(styles.container, styles.borderBottom)}>
-        {issue.repository_url &&
+        {issue.repository_url && (
           <ListItem
             title={issue.repository_url.replace(`${v3.root}/repos/`, '')}
             titleStyle={styles.titleSmall}
@@ -125,7 +127,8 @@ export class IssueDescription extends Component {
             }}
             onPress={() => onRepositoryPress(issue.repository_url)}
             hideChevron
-          />}
+          />
+        )}
 
         <View style={styles.headerContainer}>
           <ListItem
@@ -144,67 +147,75 @@ export class IssueDescription extends Component {
 
           {!issue.pull_request ||
             (issue.pull_request &&
-              !isPendingCheckMerge &&
-              <StateBadge
-                style={styles.badge}
-                issue={issue}
-                isMerged={isMerged && issue.pull_request}
-                language={language}
-              />)}
+              !isPendingCheckMerge && (
+                <StateBadge
+                  style={styles.badge}
+                  issue={issue}
+                  isMerged={isMerged && issue.pull_request}
+                  language={language}
+                />
+              ))}
         </View>
 
-        {issue.pull_request &&
+        {issue.pull_request && (
           <View style={styles.diffBlocksContainer}>
-            {isPendingDiff &&
-              <ActivityIndicator animating={isPendingDiff} size="small" />}
+            {isPendingDiff && (
+              <ActivityIndicator animating={isPendingDiff} size="small" />
+            )}
 
             {!isPendingDiff &&
-              (lineAdditions !== 0 || lineDeletions !== 0) &&
-              <DiffBlocks
-                additions={lineAdditions}
-                deletions={lineDeletions}
-                showNumbers
-                onPress={() =>
-                  navigation.navigate('PullDiff', {
-                    title: translate('repository.pullDiff.title', language),
-                    language,
-                    diff,
-                  })}
-              />}
-          </View>}
+              (lineAdditions !== 0 || lineDeletions !== 0) && (
+                <DiffBlocks
+                  additions={lineAdditions}
+                  deletions={lineDeletions}
+                  showNumbers
+                  onPress={() =>
+                    navigation.navigate('PullDiff', {
+                      title: translate('repository.pullDiff.title', language),
+                      language,
+                      diff,
+                    })}
+                />
+              )}
+          </View>
+        )}
 
         {issue.labels &&
-          issue.labels.length > 0 &&
-          <View style={styles.labelButtonGroup}>
-            {this.renderLabelButtons(issue.labels)}
-          </View>}
+          issue.labels.length > 0 && (
+            <View style={styles.labelButtonGroup}>
+              {this.renderLabelButtons(issue.labels)}
+            </View>
+          )}
         {issue.assignees &&
-          issue.assignees.length > 0 &&
-          <View style={styles.assigneesSection}>
-            <MembersList
-              title={translate('issue.main.assignees', language)}
-              members={issue.assignees}
-              containerStyle={{ marginTop: 0, paddingTop: 0, paddingLeft: 0 }}
-              smallTitle
-              navigation={navigation}
-            />
-          </View>}
+          issue.assignees.length > 0 && (
+            <View style={styles.assigneesSection}>
+              <MembersList
+                title={translate('issue.main.assignees', language)}
+                members={issue.assignees}
+                containerStyle={{ marginTop: 0, paddingTop: 0, paddingLeft: 0 }}
+                smallTitle
+                navigation={navigation}
+              />
+            </View>
+          )}
 
         {issue.pull_request &&
           !isMerged &&
           issue.state === 'open' &&
-          userHasPushPermission &&
-          <View style={styles.mergeButtonContainer}>
-            <Button
-              type="success"
-              icon={{ name: 'git-merge', type: 'octicon' }}
-              onPress={() =>
-                navigation.navigate('PullMerge', {
-                  title: translate('issue.pullMerge.title', language),
-                })}
-              title={translate('issue.main.mergeButton', language)}
-            />
-          </View>}
+          userHasPushPermission && (
+            <View style={styles.mergeButtonContainer}>
+              <Button
+                type={isMergeable ? 'success' : 'default'}
+                icon={{ name: 'git-merge', type: 'octicon' }}
+                disabled={!isMergeable}
+                onPress={() =>
+                  navigation.navigate('PullMerge', {
+                    title: translate('issue.pullMerge.title', language),
+                  })}
+                title={translate('issue.main.mergeButton', language)}
+              />
+            </View>
+          )}
       </View>
     );
   }

--- a/src/issue/issue.action.js
+++ b/src/issue/issue.action.js
@@ -17,6 +17,7 @@ import {
   CHANGE_LOCK_STATUS,
   GET_ISSUE_DIFF,
   GET_ISSUE_MERGE_STATUS,
+  GET_PULL_REQUEST_FROM_URL,
   MERGE_PULL_REQUEST,
   GET_ISSUE_FROM_URL,
   SUBMIT_NEW_ISSUE,
@@ -69,10 +70,34 @@ const getMergeStatus = (repo, issueNum) => {
   };
 };
 
+const getPullRequest = url => {
+  return (dispatch, getState) => {
+    const accessToken = getState().auth.accessToken;
+
+    dispatch({ type: GET_PULL_REQUEST_FROM_URL.PENDING });
+
+    return v3
+      .getJson(url, accessToken)
+      .then(pr => {
+        dispatch({
+          type: GET_PULL_REQUEST_FROM_URL.SUCCESS,
+          payload: pr,
+        });
+      })
+      .catch(error => {
+        dispatch({
+          type: GET_PULL_REQUEST_FROM_URL.ERROR,
+          payload: error,
+        });
+      });
+  };
+};
+
 const getPullRequestDetails = issue => {
   return (dispatch, getState) => {
     const repoFullName = getState().repository.repository.full_name;
 
+    dispatch(getPullRequest(issue.pull_request.url));
     dispatch(getDiff(issue.pull_request.url));
     dispatch(getMergeStatus(repoFullName, issue.number));
   };

--- a/src/issue/issue.reducer.js
+++ b/src/issue/issue.reducer.js
@@ -8,6 +8,7 @@ import {
   CHANGE_LOCK_STATUS,
   GET_ISSUE_DIFF,
   GET_ISSUE_MERGE_STATUS,
+  GET_PULL_REQUEST_FROM_URL,
   MERGE_PULL_REQUEST,
   GET_ISSUE_FROM_URL,
   SUBMIT_NEW_ISSUE,
@@ -16,6 +17,7 @@ import {
 const initialState = {
   issue: {},
   comments: [],
+  pr: {},
   diff: '',
   isMerged: false,
   isPendingComments: false,
@@ -221,6 +223,23 @@ export const issueReducer = (state = initialState, action = {}) => {
         ...state,
         error: action.payload,
         isPendingMerging: false,
+      };
+    case GET_PULL_REQUEST_FROM_URL.PENDING:
+      return {
+        ...state,
+        isPendingPR: true,
+      };
+    case GET_PULL_REQUEST_FROM_URL.SUCCESS:
+      return {
+        ...state,
+        pr: action.payload,
+        isPendingPR: false,
+      };
+    case GET_PULL_REQUEST_FROM_URL.ERROR:
+      return {
+        ...state,
+        error: action.payload,
+        isPendingPR: false,
       };
     case GET_ISSUE_FROM_URL.PENDING:
       return {

--- a/src/issue/issue.type.js
+++ b/src/issue/issue.type.js
@@ -9,6 +9,9 @@ export const EDIT_ISSUE_BODY = createActionSet('EDIT_ISSUE_BODY');
 export const CHANGE_LOCK_STATUS = createActionSet('CHANGE_LOCK_STATUS');
 export const GET_ISSUE_DIFF = createActionSet('GET_ISSUE_DIFF');
 export const GET_ISSUE_MERGE_STATUS = createActionSet('GET_ISSUE_MERGE_STATUS');
+export const GET_PULL_REQUEST_FROM_URL = createActionSet(
+  'GET_PULL_REQUEST_FROM_URL'
+);
 export const MERGE_PULL_REQUEST = createActionSet('MERGE_PULL_REQUEST');
 export const GET_ISSUE_FROM_URL = createActionSet('GET_ISSUE_FROM_URL');
 export const SUBMIT_NEW_ISSUE = createActionSet('SUBMIT_NEW_ISSUE');


### PR DESCRIPTION
Fixes #128.

The main idea is to leverage the field `mergeable` provided by [the pull request API](https://developer.github.com/v3/pulls/#get-a-single-pull-request). Besides, I refactor a little about the logic of fetching a issue. That's because I want to only fetch pull request if the issue is a pull request. At last, I find out some basic fields are still needed by using the issue API, so I give up the API replacement but keep the refactor.