### PR TITLE
fix(notification): Avoid repo names include keyword

### DIFF
--- a/src/notifications/screens/notifications.screen.js
+++ b/src/notifications/screens/notifications.screen.js
@@ -339,7 +339,7 @@ class Notifications extends Component {
 
     markAsRead(notification.id);
     navigation.navigate('Issue', {
-      issueURL: notification.subject.url.replace('pulls', 'issues'),
+      issueURL: notification.subject.url.replace(/pulls\/(\d+)$/, 'issues/$1'),
       isPR: notification.subject.type === 'PullRequest',
       language: this.props.language,
     });


### PR DESCRIPTION
The original replacement is not very safe, i.e,

```
'https://github.com/schacon/git-pulls/pulls/64'.replace('pulls', 'issues')
-> "https://github.com/schacon/git-issues/pulls/64"

'https://github.com/schacon/git-pulls/pulls/64'.replace(/pulls\/(\d+)$/, 'issues/$1')
-> "https://github.com/schacon/git-pulls/issues/64"
```