### PR TITLE
fix(editissuecomment, textinput): Fix height rendering for Android

### DIFF
--- a/src/issue/screens/edit-issue-comment.screen.js
+++ b/src/issue/screens/edit-issue-comment.screen.js
@@ -18,7 +18,6 @@ import { editIssueBody, editIssueComment } from '../issue.action';
 
 const styles = StyleSheet.create({
   textInput: {
-    maxHeight: Dimensions.get('window').height / 2,
     paddingVertical: 10,
     fontSize: normalize(12),
     marginHorizontal: 15,
@@ -116,7 +115,13 @@ class EditIssueComment extends Component {
                   issueCommentHeight: event.nativeEvent.contentSize.height,
                 })}
               placeholderTextColor={colors.grey}
-              style={styles.textInput}
+              style={[
+                styles.textInput,
+                {
+                  height: this.state.issueCommentHeight,
+                  maxHeight: Dimensions.get('window').height / 2,
+                },
+              ]}
               value={issueComment}
             />
           </SectionList>


### PR DESCRIPTION
For #423 

`onContentSizeChange` doesn't seem to fire when the component mounts @jouderianjr so adding a height property seems to fix it

![image](https://user-images.githubusercontent.com/12476932/31183422-8ef72532-a8f4-11e7-99dc-95e926ad6e38.png)
