### PR TITLE
docs: add a couple of doc improvements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,8 @@ Please feel free to take on any issue that's currently open. Feel free to resolv
 2. Clone your fork
 3. Make a branch for your feature or bug fix
 4. Follow the [React Native Guide](https://facebook.github.io/react-native/docs/getting-started.html) for learning how to get started with building a project with native iOS code (a Mac is required)
-5. The `CLIENT_ID` and `CLIENT_SECRET` in `api/index.js` are for development purposes and do not represent the actual application keys. Feel free to use them or use a new set of keys by creating an [OAuth application](https://github.com/settings/applications/new) of your own
+5. The `CLIENT_ID` and `CLIENT_SECRET` in `api/index.js` are for development purposes and do not represent the actual application keys. Feel free to use them or use a new set of keys by creating an [OAuth application](https://github.com/settings/applications/new) of your own.
+    - Set the "Authorization callback URL" to `gitpoint://welcome`.
 6. `yarn` to install dependencies
 7. `yarn run link` to link react-native dependencies
 8. Use one of the following commands depending on the target platform:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ If you want to open a PR that fixes a bug or adds a feature, then we can't thank
 
 ### Working on issues
 
-Please feel free to take on any issue that's currently open. To streamline priorities, we've created a [project](https://github.com/gitpoint/git-point/projects/1) to define the priority order of the different issues. It would be preferred if you can tackle a high priority issue, but if you can’t, feel free to resolve any issue that you would enjoy working on even if it happens to be a low priority.
+Please feel free to take on any issue that's currently open. Feel free to resolve any issue that you would enjoy working on even if it happens to be a low priority.
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Also, if there's anything you'd like to chat about, please feel free to join our
 
 Please take a look at the [contributing guidelines](./CONTRIBUTING.md) for a detailed process on how to build your application as well as troubleshooting information.
 
-**Development Keys**: The `CLIENT_ID` and `CLIENT_SECRET` in `api/index.js` are for development purposes and do not represent the actual application keys. Feel free to use them or use a new set of keys by creating an [OAuth application](https://github.com/settings/applications/new) of your own
+**Development Keys**: The `CLIENT_ID` and `CLIENT_SECRET` in `api/index.js` are for development purposes and do not represent the actual application keys. Feel free to use them or use a new set of keys by creating an [OAuth application](https://github.com/settings/applications/new) of your own. Set the "Authorization callback URL" to `gitpoint://welcome`.
 
 ## Backers [![Backers on Open Collective](https://opencollective.com/git-point/backers/badge.svg)](#backers)
 


### PR DESCRIPTION
This branch:

- Removes a broken link to a project from the contributing doc.
- Notes what I think the "Authorization callback URL" should be, if you choose to create an OAuth app on GitHub to develop GitPoint locally.