### PR TITLE
fix(translation): add missing string to translations

### DIFF
--- a/src/locale/languages/en.js
+++ b/src/locale/languages/en.js
@@ -231,6 +231,7 @@ export const en = {
     },
     readMe: {
       readMeActions: 'README Actions',
+      noReadMeFound: 'No README.md found',
     },
   },
   organization: {

--- a/src/locale/languages/es.js
+++ b/src/locale/languages/es.js
@@ -222,6 +222,7 @@ export const erase = {
       fileRenamed: 'File renamed without any changes',
     },
     readMe: {
+      readMeActions: 'README Actions',
       noReadMeFound: 'No README.md found',
     },
   },

--- a/src/locale/languages/es.js
+++ b/src/locale/languages/es.js
@@ -222,8 +222,8 @@ export const erase = {
       fileRenamed: 'File renamed without any changes',
     },
     readMe: {
-      readMeActions: 'README Actions',
-      noReadMeFound: 'No README.md found',
+      readMeActions: 'Acciones README',
+      noReadMeFound: 'No se ha encontrado README.md',
     },
   },
   organization: {

--- a/src/locale/languages/es.js
+++ b/src/locale/languages/es.js
@@ -221,6 +221,9 @@ export const erase = {
       deleted: 'DELETED',
       fileRenamed: 'File renamed without any changes',
     },
+    readMe: {
+      noReadMeFound: 'No README.md found',
+    },
   },
   organization: {
     main: {

--- a/src/locale/languages/fr.js
+++ b/src/locale/languages/fr.js
@@ -228,7 +228,7 @@ export const fr = {
     },
     readMe: {
       readMeActions: 'Actions sur le README',
-      noReadMeFound: 'No README.md found',
+      noReadMeFound: 'Pas de README.md trouvé',
     },
   },
   organization: {

--- a/src/locale/languages/fr.js
+++ b/src/locale/languages/fr.js
@@ -228,6 +228,7 @@ export const fr = {
     },
     readMe: {
       readMeActions: 'Actions sur le README',
+      noReadMeFound: 'No README.md found',
     },
   },
   organization: {

--- a/src/locale/languages/gl.js
+++ b/src/locale/languages/gl.js
@@ -231,7 +231,7 @@ export const gl = {
     },
     readMe: {
       readMeActions: 'Accións do README',
-      noReadMeFound: 'No README.md found',
+      noReadMeFound: 'Non se atopou o README.md',
     },
   },
   organization: {

--- a/src/locale/languages/gl.js
+++ b/src/locale/languages/gl.js
@@ -231,6 +231,7 @@ export const gl = {
     },
     readMe: {
       readMeActions: 'Accións do README',
+      noReadMeFound: 'No README.md found',
     },
   },
   organization: {

--- a/src/locale/languages/nl.js
+++ b/src/locale/languages/nl.js
@@ -224,7 +224,7 @@ export const nl = {
     },
     readMe: {
       readMeActions: 'README Acties',
-      noReadMeFound: 'No README.md found',
+      noReadMeFound: 'Geen README.md gevonden',
     },
   },
   organization: {

--- a/src/locale/languages/nl.js
+++ b/src/locale/languages/nl.js
@@ -224,6 +224,7 @@ export const nl = {
     },
     readMe: {
       readMeActions: 'README Acties',
+      noReadMeFound: 'No README.md found',
     },
   },
   organization: {
@@ -274,7 +275,8 @@ export const nl = {
         pullRequest: 'Pull Request',
       },
       openIssueSubTitle: '#{{number}} geopend {{time}} geleden door {{user}}',
-      closedIssueSubTitle: '#{{number}} door {{user}} was gesloten, {{time}} geleden',
+      closedIssueSubTitle:
+        '#{{number}} door {{user}} was gesloten, {{time}} geleden',
       issueActions: 'Issue Acties',
     },
     newIssue: {

--- a/src/locale/languages/pt-br.js
+++ b/src/locale/languages/pt-br.js
@@ -228,6 +228,7 @@ export const ptBr = {
     },
     readMe: {
       readMeActions: 'Ações do README',
+      noReadMeFound: 'No README.md found',
     },
   },
   organization: {

--- a/src/locale/languages/pt-br.js
+++ b/src/locale/languages/pt-br.js
@@ -228,7 +228,7 @@ export const ptBr = {
     },
     readMe: {
       readMeActions: 'Ações do README',
-      noReadMeFound: 'No README.md found',
+      noReadMeFound: 'Nenhum README.md foi encontrado',
     },
   },
   organization: {

--- a/src/locale/languages/pt.js
+++ b/src/locale/languages/pt.js
@@ -229,8 +229,8 @@ export const pt = {
       fileRenamed: 'O ficheiro mudou de nome sem qualquer alteração',
     },
     readMe: {
-      readMeActions: 'README Actions',
-      noReadMeFound: 'No README.md found',
+      readMeActions: 'Acções sobre o ficheiro README',
+      noReadMeFound: 'Não foi encontrado nenhum ficheiro README.md',
     },
   },
   organization: {

--- a/src/locale/languages/pt.js
+++ b/src/locale/languages/pt.js
@@ -228,6 +228,9 @@ export const pt = {
       deleted: 'REMOVIDO',
       fileRenamed: 'O ficheiro mudou de nome sem qualquer alteração',
     },
+    readMe: {
+      noReadMeFound: 'No README.md found',
+    },
   },
   organization: {
     main: {

--- a/src/locale/languages/pt.js
+++ b/src/locale/languages/pt.js
@@ -229,6 +229,7 @@ export const pt = {
       fileRenamed: 'O ficheiro mudou de nome sem qualquer alteração',
     },
     readMe: {
+      readMeActions: 'README Actions',
       noReadMeFound: 'No README.md found',
     },
   },

--- a/src/locale/languages/ru.js
+++ b/src/locale/languages/ru.js
@@ -229,7 +229,7 @@ export const ru = {
     },
     readMe: {
       readMeActions: 'Действия с README',
-      noReadMeFound: 'No README.md found',
+      noReadMeFound: 'He yдалось найти README.md',
     },
   },
   organization: {

--- a/src/locale/languages/ru.js
+++ b/src/locale/languages/ru.js
@@ -229,6 +229,7 @@ export const ru = {
     },
     readMe: {
       readMeActions: 'Действия с README',
+      noReadMeFound: 'No README.md found',
     },
   },
   organization: {

--- a/src/locale/languages/tr.js
+++ b/src/locale/languages/tr.js
@@ -228,7 +228,7 @@ export const tr = {
     },
     readMe: {
       readMeActions: 'README Actions',
-      noReadMeFound: 'No README.md found',
+      noReadMeFound: 'README.md bulunamadı',
     },
   },
   organization: {

--- a/src/locale/languages/tr.js
+++ b/src/locale/languages/tr.js
@@ -228,6 +228,7 @@ export const tr = {
     },
     readMe: {
       readMeActions: 'README Actions',
+      noReadMeFound: 'No README.md found',
     },
   },
   organization: {

--- a/src/repository/screens/read-me.screen.js
+++ b/src/repository/screens/read-me.screen.js
@@ -114,7 +114,9 @@ class ReadMe extends Component {
         {!isPendingReadMe &&
           noReadMe && (
             <View style={styles.textContainer}>
-              <Text style={styles.noReadMeTitle}>No README.md found</Text>
+              <Text style={styles.noReadMeTitle}>
+                {translate('repository.readMe.noReadMeFound', language)}
+              </Text>
             </View>
           )}
 


### PR DESCRIPTION
Hey guys,

i found a string in `readme.screen.js`
I added it to the translation files but the translators need to translate it now.

Im not sure, probably @housseindjirdeh wanted this string to be not translate or it was just overseen somehow. If its wanted this way please close this pr.

Thank you guys