### PR TITLE
fix(issue): Consolidate issue link parsing

### DIFF
--- a/routes.js
+++ b/routes.js
@@ -132,7 +132,7 @@ const sharedRoutes = {
   Issue: {
     screen: IssueScreen,
     navigationOptions: ({ navigation }) => {
-      const issueNumberRegex = /issues\/([0-9]+)$/;
+      const issueNumberRegex = /issues\/([0-9]+)(#|$)/;
       const { issue, issueURL, isPR, language } = navigation.state.params;
       const number = issue ? issue.number : issueURL.match(issueNumberRegex)[1];
       const langKey = isPR ? 'pullRequest' : 'issue';


### PR DESCRIPTION
~~Fixes~~ Discovered in #462.

The regular expression can't match anything if `issueURL` is a issue comment, like `https://github.com/octokit/discussions/issues/7#issuecomment-327616339`. It causes `[1]` throws an error.

```
const issueNumberRegex = /issues\/([0-9]+)$/;
const { issue, issueURL, isPR, language } = navigation.state.params;
const number = issue ? issue.number : issueURL.match(issueNumberRegex)[1];
```