### PR TITLE
fix(md): Play nice with anchors

### DIFF
--- a/src/components/github-htmlview.component.js
+++ b/src/components/github-htmlview.component.js
@@ -319,13 +319,18 @@ export class GithubHtmlView extends Component {
           );
         },
         a: (node, index, siblings, parent, defaultRenderer) => {
+          if (typeof node.children[0] === 'undefined') {
+            // Probably a named anchor, ignore it for now & avoid extra space.
+            return null;
+          }
+
           return (
             <Text
               key={index}
               style={styles.strong}
               onPress={() => onLinkPress(node)}
             >
-              {node.children[0].data}
+              {defaultRenderer(node.children, node)}
             </Text>
           );
         },


### PR DESCRIPTION
Fix a new markdown bug, this time with anchors.
Also got rid of `node.children[0].data` in favor of `defaultRenderer(node.children, node)`, so that links containing more than a single text child are well rendered.

Like this one for example with the commit hash at the end: https://github.com/machour/git-point-playground/commit/4872692e48c9b18c8df9ec8acadbbfab2306d1c6

Fixes #462 