### PR TITLE
chore: disable OS_ACTIVITY_MODE in Debug mode

### DIFF
--- a/ios/GitPoint.xcodeproj/xcshareddata/xcschemes/GitPoint.xcscheme
+++ b/ios/GitPoint.xcodeproj/xcshareddata/xcschemes/GitPoint.xcscheme
@@ -54,6 +54,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
@@ -73,6 +74,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
@@ -89,6 +91,13 @@
             ReferencedContainer = "container:GitPoint.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "OS_ACTIVITY_MODE"
+            value = "disable"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>


### PR DESCRIPTION
When using xcode, logs are flooded with this message (X incrementing every 2 seconds):
`[] nw_connection_get_connected_socket_block_invoke X Connection has no connected handler`

setting OS_ACTIVITY_MODE = disable fixes it, and logs are bearable again