### PR TITLE
refactor(*): cleanup code using prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "commitmsg": "minicat $GIT_PARAMS | commitlint",
     "precommit": "lint-staged",
     "eslint": "eslint .",
+    "prettier": "prettier --single-quote --trailing-comma es5 --write \"**/*.js\"",
     "test": "jest",
     "flow-start": "flow start",
     "flow-stop": "flow stop",

--- a/src/auth/screens/events.screen.js
+++ b/src/auth/screens/events.screen.js
@@ -27,7 +27,7 @@ const mapDispatchToProps = dispatch =>
       getNotificationsCount,
       getUser,
     },
-    dispatch,
+    dispatch
   );
 
 const styles = StyleSheet.create({
@@ -170,7 +170,7 @@ class Events extends Component {
             language,
             {
               action: translate('auth.events.actions.commented', language),
-            },
+            }
           );
         } else if (action === 'edited') {
           return translate(
@@ -178,7 +178,7 @@ class Events extends Component {
             language,
             {
               action: translate(`auth.events.actions.${action}`, language),
-            },
+            }
           );
         } else if (action === 'deleted') {
           return translate(
@@ -186,7 +186,7 @@ class Events extends Component {
             language,
             {
               action: translate(`auth.events.actions.${action}`, language),
-            },
+            }
           );
         }
 
@@ -466,7 +466,7 @@ class Events extends Component {
         ? {
             ...userEvent.repo,
             name: userEvent.repo.name.substring(
-              userEvent.repo.name.indexOf('/') + 1,
+              userEvent.repo.name.indexOf('/') + 1
             ),
           }
         : userEvent.payload.forkee,
@@ -564,7 +564,7 @@ class Events extends Component {
                 <View style={styles.subtitleContainer}>
                   <Text numberOfLines={3} style={styles.subtitle}>
                     {emojifyText(
-                      item.payload.comment.body.replace(linebreaksPattern, ' '),
+                      item.payload.comment.body.replace(linebreaksPattern, ' ')
                     )}
                   </Text>
                 </View>}
@@ -583,5 +583,5 @@ class Events extends Component {
 }
 
 export const EventsScreen = connect(mapStateToProps, mapDispatchToProps)(
-  Events,
+  Events
 );

--- a/src/auth/screens/user-options.screen.js
+++ b/src/auth/screens/user-options.screen.js
@@ -173,7 +173,9 @@ class UserOptions extends Component {
                         <Text style={styles.flag}>
                           {emojifyText(item.emojiCode)}
                         </Text>
-                        <Text style={styles.listTitle}>{item.name}</Text>
+                        <Text style={styles.listTitle}>
+                          {item.name}
+                        </Text>
                       </View>
                     }
                     titleStyle={styles.listTitle}
@@ -225,7 +227,9 @@ class UserOptions extends Component {
           </SectionList>
 
           <TouchableOpacity style={styles.update} onPress={this.checkForUpdate}>
-            <Text style={styles.updateText}>GitPoint v{version}</Text>
+            <Text style={styles.updateText}>
+              GitPoint v{version}
+            </Text>
             <Text style={[styles.updateText, styles.updateTextSub]}>
               {this.state.updateText}
             </Text>

--- a/src/components/comment-list-item.component.js
+++ b/src/components/comment-list-item.component.js
@@ -145,7 +145,7 @@ class CommentListItemComponent extends Component {
                     : 'Profile',
                   {
                     user: comment.user,
-                  },
+                  }
                 )}
             >
               <Image
@@ -166,7 +166,7 @@ class CommentListItemComponent extends Component {
                     : 'Profile',
                   {
                     user: comment.user,
-                  },
+                  }
                 )}
             >
               <Text style={styles.linkDescription}>
@@ -227,5 +227,5 @@ class CommentListItemComponent extends Component {
 }
 
 export const CommentListItem = connect(mapStateToProps)(
-  CommentListItemComponent,
+  CommentListItemComponent
 );

--- a/src/components/issue-description.component.js
+++ b/src/components/issue-description.component.js
@@ -115,7 +115,7 @@ export class IssueDescription extends Component {
 
     return (
       <View style={(styles.container, styles.borderBottom)}>
-        {issue.repository_url && (
+        {issue.repository_url &&
           <ListItem
             title={issue.repository_url.replace(`${v3.root}/repos/`, '')}
             titleStyle={styles.titleSmall}
@@ -127,8 +127,7 @@ export class IssueDescription extends Component {
             }}
             onPress={() => onRepositoryPress(issue.repository_url)}
             hideChevron
-          />
-        )}
+          />}
 
         <View style={styles.headerContainer}>
           <ListItem
@@ -147,75 +146,68 @@ export class IssueDescription extends Component {
 
           {!issue.pull_request ||
             (issue.pull_request &&
-              !isPendingCheckMerge && (
-                <StateBadge
-                  style={styles.badge}
-                  issue={issue}
-                  isMerged={isMerged && issue.pull_request}
-                  language={language}
-                />
-              ))}
+              !isPendingCheckMerge &&
+              <StateBadge
+                style={styles.badge}
+                issue={issue}
+                isMerged={isMerged && issue.pull_request}
+                language={language}
+              />)}
         </View>
 
-        {issue.pull_request && (
+        {issue.pull_request &&
           <View style={styles.diffBlocksContainer}>
-            {isPendingDiff && (
-              <ActivityIndicator animating={isPendingDiff} size="small" />
-            )}
+            {isPendingDiff &&
+              <ActivityIndicator animating={isPendingDiff} size="small" />}
 
             {!isPendingDiff &&
-              (lineAdditions !== 0 || lineDeletions !== 0) && (
-                <DiffBlocks
-                  additions={lineAdditions}
-                  deletions={lineDeletions}
-                  showNumbers
-                  onPress={() =>
-                    navigation.navigate('PullDiff', {
-                      title: translate('repository.pullDiff.title', language),
-                      language,
-                      diff,
-                    })}
-                />
-              )}
-          </View>
-        )}
+              (lineAdditions !== 0 || lineDeletions !== 0) &&
+              <DiffBlocks
+                additions={lineAdditions}
+                deletions={lineDeletions}
+                showNumbers
+                onPress={() =>
+                  navigation.navigate('PullDiff', {
+                    title: translate('repository.pullDiff.title', language),
+                    language,
+                    diff,
+                  })}
+              />}
+          </View>}
 
         {issue.labels &&
-          issue.labels.length > 0 && (
-            <View style={styles.labelButtonGroup}>
-              {this.renderLabelButtons(issue.labels)}
-            </View>
-          )}
+          issue.labels.length > 0 &&
+          <View style={styles.labelButtonGroup}>
+            {this.renderLabelButtons(issue.labels)}
+          </View>}
         {issue.assignees &&
-          issue.assignees.length > 0 && (
-            <View style={styles.assigneesSection}>
-              <MembersList
-                title={translate('issue.main.assignees', language)}
-                members={issue.assignees}
-                containerStyle={{ marginTop: 0, paddingTop: 0, paddingLeft: 0 }}
-                smallTitle
-                navigation={navigation}
-              />
-            </View>
-          )}
+          issue.assignees.length > 0 &&
+          <View style={styles.assigneesSection}>
+            <MembersList
+              title={translate('issue.main.assignees', language)}
+              members={issue.assignees}
+              containerStyle={{ marginTop: 0, paddingTop: 0, paddingLeft: 0 }}
+              smallTitle
+              navigation={navigation}
+            />
+          </View>}
 
         {issue.pull_request &&
           !isMerged &&
           issue.state === 'open' &&
-          userHasPushPermission && (
-            <View style={styles.mergeButtonContainer}>
-              <Button
-                type={isMergeable ? 'success' : 'default'}
-                icon={{ name: 'git-merge', type: 'octicon' }}
-                disabled={!isMergeable}
-                onPress={() =>
-                  navigation.navigate('PullMerge', {
-                    title: translate('issue.pullMerge.title', language),
-                  })}
-                title={translate('issue.main.mergeButton', language)}
-              />
-            </View>
-          )}
+          userHasPushPermission &&
+          <View style={styles.mergeButtonContainer}>
+            <Button
+              type={isMergeable ? 'success' : 'default'}
+              icon={{ name: 'git-merge', type: 'octicon' }}
+              disabled={!isMergeable}
+              onPress={() =>
+                navigation.navigate('PullMerge', {
+                  title: translate('issue.pullMerge.title', language),
+                })}
+              title={translate('issue.main.mergeButton', language)}
+            />
+          </View>}
       </View>
     );
   }

--- a/src/issue/screens/edit-issue-comment.screen.js
+++ b/src/issue/screens/edit-issue-comment.screen.js
@@ -52,7 +52,7 @@ const mapDispatchToProps = dispatch =>
       editIssueBody,
       editIssueComment,
     },
-    dispatch,
+    dispatch
   );
 
 class EditIssueComment extends Component {
@@ -145,5 +145,5 @@ class EditIssueComment extends Component {
 
 export const EditIssueCommentScreen = connect(
   mapStateToProps,
-  mapDispatchToProps,
+  mapDispatchToProps
 )(EditIssueComment);

--- a/src/issue/screens/issue-settings.screen.js
+++ b/src/issue/screens/issue-settings.screen.js
@@ -172,7 +172,7 @@ class IssueSettings extends Component {
             noItemsMessage={translate('issue.settings.noneMessage', language)}
             title={translate('issue.settings.labelsTitle', language)}
           >
-            {issue.labels.map(item => (
+            {issue.labels.map(item =>
               <LabelListItem
                 label={item}
                 key={item.id}
@@ -194,7 +194,7 @@ class IssueSettings extends Component {
                     }
                   )}
               />
-            ))}
+            )}
           </SectionList>
 
           <SectionList
@@ -221,7 +221,7 @@ class IssueSettings extends Component {
             noItemsMessage={translate('issue.settings.noneMessage', language)}
             title={translate('issue.settings.assigneesTitle', language)}
           >
-            {issue.assignees.map(item => (
+            {issue.assignees.map(item =>
               <UserListItem
                 user={item}
                 key={item.id}
@@ -243,7 +243,7 @@ class IssueSettings extends Component {
                     }
                   )}
               />
-            ))}
+            )}
           </SectionList>
 
           <SectionList
@@ -265,7 +265,7 @@ class IssueSettings extends Component {
               onPress={this.showLockIssueActionSheet}
             />
 
-            {!isMerged && (
+            {!isMerged &&
               <ListItem
                 title={
                   issue.state === 'open'
@@ -284,8 +284,7 @@ class IssueSettings extends Component {
                     : styles.openActionTitle
                 }
                 onPress={this.showChangeIssueStateActionSheet}
-              />
-            )}
+              />}
           </SectionList>
 
           <SectionList>

--- a/src/issue/screens/issue.screen.js
+++ b/src/issue/screens/issue.screen.js
@@ -333,46 +333,44 @@ class Issue extends Component {
 
     return (
       <ViewContainer>
-        {isShowLoadingContainer && (
-          <LoadingContainer animating={isShowLoadingContainer} center />
-        )}
+        {isShowLoadingContainer &&
+          <LoadingContainer animating={isShowLoadingContainer} center />}
 
         {!isPendingComments &&
           !isPendingIssue &&
-          issue && (
-            <KeyboardAvoidingView
-              style={{ flex: 1 }}
-              behavior={'padding'}
-              keyboardVerticalOffset={Platform.select({
-                ios: 65,
-                android: -200,
-              })}
-            >
-              <FlatList
-                ref={ref => {
-                  this.commentsList = ref;
-                }}
-                refreshing={isLoadingData}
-                onRefresh={this.getIssueInformation}
-                contentContainerStyle={{ flexGrow: 1 }}
-                ListHeaderComponent={this.renderHeader}
-                removeClippedSubviews={false}
-                data={fullComments}
-                keyExtractor={this.keyExtractor}
-                renderItem={this.renderItem}
-              />
+          issue &&
+          <KeyboardAvoidingView
+            style={{ flex: 1 }}
+            behavior={'padding'}
+            keyboardVerticalOffset={Platform.select({
+              ios: 65,
+              android: -200,
+            })}
+          >
+            <FlatList
+              ref={ref => {
+                this.commentsList = ref;
+              }}
+              refreshing={isLoadingData}
+              onRefresh={this.getIssueInformation}
+              contentContainerStyle={{ flexGrow: 1 }}
+              ListHeaderComponent={this.renderHeader}
+              removeClippedSubviews={false}
+              data={fullComments}
+              keyExtractor={this.keyExtractor}
+              renderItem={this.renderItem}
+            />
 
-              <CommentInput
-                users={fullUsers}
-                userHasPushPermission={
-                  navigation.state.params.userHasPushPermission
-                }
-                issueLocked={issue.locked}
-                language={language}
-                onSubmit={this.postComment}
-              />
-            </KeyboardAvoidingView>
-          )}
+            <CommentInput
+              users={fullUsers}
+              userHasPushPermission={
+                navigation.state.params.userHasPushPermission
+              }
+              issueLocked={issue.locked}
+              language={language}
+              onSubmit={this.postComment}
+            />
+          </KeyboardAvoidingView>}
 
         <ActionSheet
           ref={o => {

--- a/src/issue/screens/new-issue.screen.js
+++ b/src/issue/screens/new-issue.screen.js
@@ -43,7 +43,7 @@ const mapDispatchToProps = dispatch =>
     {
       submitNewIssue,
     },
-    dispatch,
+    dispatch
   );
 
 class NewIssue extends Component {
@@ -81,7 +81,7 @@ class NewIssue extends Component {
       Alert.alert(
         translate('issue.newIssue.missingTitleAlert', language),
         null,
-        [{ text: translate('common.ok', language) }],
+        [{ text: translate('common.ok', language) }]
       );
     } else {
       submitNewIssue(owner, repoName, issueTitle, issueComment).then(issue => {
@@ -173,5 +173,5 @@ class NewIssue extends Component {
 }
 
 export const NewIssueScreen = connect(mapStateToProps, mapDispatchToProps)(
-  NewIssue,
+  NewIssue
 );

--- a/src/issue/screens/pull-merge.screen.js
+++ b/src/issue/screens/pull-merge.screen.js
@@ -23,7 +23,7 @@ const mapDispatchToProps = dispatch =>
     {
       mergePullRequest,
     },
-    dispatch,
+    dispatch
   );
 
 const styles = StyleSheet.create({
@@ -125,7 +125,7 @@ class PullMerge extends Component {
       Alert.alert(
         translate('issue.pullMerge.missingTitleAlert', language),
         null,
-        [{ text: translate('common.ok', language) }],
+        [{ text: translate('common.ok', language) }]
       );
     } else {
       mergePullRequest(
@@ -133,7 +133,7 @@ class PullMerge extends Component {
         issue.number,
         commitTitle,
         commitMessage,
-        mergeMethodTypes[mergeMethod],
+        mergeMethodTypes[mergeMethod]
       ).then(() => {
         navigation.goBack();
       });
@@ -234,5 +234,5 @@ class PullMerge extends Component {
 }
 
 export const PullMergeScreen = connect(mapStateToProps, mapDispatchToProps)(
-  PullMerge,
+  PullMerge
 );

--- a/src/locale/languages/eo.js
+++ b/src/locale/languages/eo.js
@@ -5,7 +5,8 @@ export const eo = {
       preparingGitPoint: 'Prepari GitPoint...',
       cancel: 'CANCELO',
       welcomeTitle: 'Bonvenon al GitPoint',
-      welcomeMessage: 'La plej karakterizaĵo riĉa GitHub-kliento, kiu estas 100% libera',
+      welcomeMessage:
+        'La plej karakterizaĵo riĉa GitHub-kliento, kiu estas 100% libera',
       notificationsTitle: 'Kontroli sciigojn',
       notificationsMessage:
         'Vidi kaj kontroli ĉiujn viajn nelegitajn kaj partoprenajn sciigojn',
@@ -13,8 +14,7 @@ export const eo = {
       reposMessage:
         'Facile akiri dosierujon, uzantojn kaj organizajn informojn',
       issuesTitle: 'Problemoj kaj Petitaj Petoj',
-      issuesMessage:
-        'Komuniki sur konversacioj, kunfandi tiri petojn kaj pli',
+      issuesMessage: 'Komuniki sur konversacioj, kunfandi tiri petojn kaj pli',
       signInButton: 'ENSALUTI',
     },
     welcome: {
@@ -22,7 +22,7 @@ export const eo = {
     },
     events: {
       welcomeMessage:
-        "Bonvenon! Ĉi tio estas via novaĵ-manĝaĵo - ĝi helpos vin resti kun freŝa agado en repositorioj, kiujn vi rigardas kaj homoj, kiujn vi sekvas.",
+        'Bonvenon! Ĉi tio estas via novaĵ-manĝaĵo - ĝi helpos vin resti kun freŝa agado en repositorioj, kiujn vi rigardas kaj homoj, kiujn vi sekvas.',
       commitCommentEvent: 'komentis fari',
       createEvent: 'kreita {{object}}',
       deleteEvent: 'forigita {{object}}',
@@ -80,7 +80,7 @@ export const eo = {
       },
     },
     profile: {
-      orgsRequestApprovalTop: "Ĉu vi ne povas vidi ĉiujn viajn organizojn?",
+      orgsRequestApprovalTop: 'Ĉu vi ne povas vidi ĉiujn viajn organizojn?',
       orgsRequestApprovalBottom: 'Vi eble devas peti aprobon por ili.',
       codePushCheck: 'Kontrolu por ĝisdatigo',
       codePushChecking: 'Kontroli por ĝisdatigo...',
@@ -99,17 +99,17 @@ export const eo = {
       title: 'Privateca Politiko',
       effectiveDate: 'Lasta ĝisdatigita: July 15, 2017',
       introduction:
-        "Ni ĝojas, ke vi decidis uzi GitPoint. Ĉi tiu Privateca Politiko estas ĉi tie por informi vin pri tio, kion ni faros - kaj ne fari - kun la datumoj de nia uzanto.",
+        'Ni ĝojas, ke vi decidis uzi GitPoint. Ĉi tiu Privateca Politiko estas ĉi tie por informi vin pri tio, kion ni faros - kaj ne fari - kun la datumoj de nia uzanto.',
       userDataTitle: 'UZANTO-DATUMOJ',
       userData1:
-        "Ni nenion faras kun via GitHub-informo. Post aŭtentikigado, la uzanto OAuth token estas persistita rekte sur ilia aparato-stokado. Ne eblas rekuperi tiun informon. Ni neniam vidos aliron al la uzanto token nek stokas ĝin.",
+        'Ni nenion faras kun via GitHub-informo. Post aŭtentikigado, la uzanto OAuth token estas persistita rekte sur ilia aparato-stokado. Ne eblas rekuperi tiun informon. Ni neniam vidos aliron al la uzanto token nek stokas ĝin.',
       userData2:
-        "Ĉi tio signifas, ke en neniu maniero, formo aŭ formo ni iam ajn vidos, uzas aŭ dividas datumojn de GitHub de uzanto. Se privataj datumoj iam ajn videblas en iu ajn punkto, ni ne registros aŭ vidos ĝin. Se ĝi hazarde registriĝas, ni forigos ĝin tuj uzante sekurajn viŝajn metodojn. Denove, ni starigis aŭtentike specife por ke ĉi tio neniam okazas.",
+        'Ĉi tio signifas, ke en neniu maniero, formo aŭ formo ni iam ajn vidos, uzas aŭ dividas datumojn de GitHub de uzanto. Se privataj datumoj iam ajn videblas en iu ajn punkto, ni ne registros aŭ vidos ĝin. Se ĝi hazarde registriĝas, ni forigos ĝin tuj uzante sekurajn viŝajn metodojn. Denove, ni starigis aŭtentike specife por ke ĉi tio neniam okazas.',
       analyticsInfoTitle: 'ANALIKA INFORMO',
       analyticsInfo1:
         'Ni nuntempe uzas Google Analytics kaj iTunes App Analytics por helpi nin mezuri trafikojn kaj uzadajn tendencojn por la GitPoint. Ĉi tiuj iloj kolektas informojn senditajn de via aparato, inkluzive de mekanismo kaj platforma versio, regiono kaj referinto. Ĉi tiu informo ne povas esti prudente uzata por identigi ajnan individuan uzanton kaj neniun personan informon ĉerpas.',
       analyticsInfo2:
-        "Se ni pasos por inkludi alian trian platformon por kolekti stakajn spurojn, erarojn-registrojn aŭ pli da analizaj informoj, ni certiĝos, ke uzantoj de datumoj restas senvaloraj kaj ĉifritaj.",
+        'Se ni pasos por inkludi alian trian platformon por kolekti stakajn spurojn, erarojn-registrojn aŭ pli da analizaj informoj, ni certiĝos, ke uzantoj de datumoj restas senvaloraj kaj ĉifritaj.',
       openSourceTitle: 'MALFERMA FONTO',
       openSource1:
         'GitPoint estas malferma fonto kaj la historio de kontribuoj al la platformo ĉiam estos videbla al la publiko.',
@@ -132,7 +132,7 @@ export const eo = {
       participatingButton: 'Partoprenanta',
       allButton: 'Ĉio',
       retrievingMessage: 'Ricevanta sciigojn',
-      noneMessage: "Vi ne havas iujn sciigojn pri ĉi tiu tipo",
+      noneMessage: 'Vi ne havas iujn sciigojn pri ĉi tiu tipo',
       markAllAsRead: 'Marki ĉion kiel legita',
     },
   },
@@ -274,7 +274,8 @@ export const eo = {
         pullRequest: 'Peti Petojn',
       },
       openIssueSubTitle: '# {{number}} malfermis {{time}} ago per {{user}}',
-      closedIssueSubTitle: '# {{number}} per {{user}} estis fermita {{time}} ago',
+      closedIssueSubTitle:
+        '# {{number}} per {{user}} estis fermita {{time}} ago',
     },
     newIssue: {
       title: 'New Issue',
@@ -294,7 +295,7 @@ export const eo = {
       commitTitle: 'Komerca Titolo',
       writeATitle: 'Skribu titolon por via kompromiso ĉi tie',
       commitMessage: 'Komitato Mesaĝo',
-      writeAMessage: "Skribu mesaĝon por via kompromiso ĉi tie",
+      writeAMessage: 'Skribu mesaĝon por via kompromiso ĉi tie',
       mergeType: 'Kombini Tipo',
       changeMergeType: 'Ŝanĝi Kombini Tipo',
     },

--- a/src/notifications/screens/notifications.screen.js
+++ b/src/notifications/screens/notifications.screen.js
@@ -58,7 +58,7 @@ const mapDispatchToProps = dispatch =>
       getNotificationsCount,
       markAllNotificationsAsRead,
     },
-    dispatch,
+    dispatch
   );
 
 const styles = StyleSheet.create({
@@ -189,7 +189,7 @@ class Notifications extends Component {
 
   getImage(repoName) {
     const notificationForRepo = this.notifications().find(
-      notification => notification.repository.full_name === repoName,
+      notification => notification.repository.full_name === repoName
     );
 
     return notificationForRepo.repository.owner.avatar_url;
@@ -226,8 +226,8 @@ class Notifications extends Component {
     const repositories = [
       ...new Set(
         this.notifications().map(
-          notification => notification.repository.full_name,
-        ),
+          notification => notification.repository.full_name
+        )
       ),
     ];
 
@@ -361,7 +361,7 @@ class Notifications extends Component {
     } = this.props;
     const { type } = this.state;
     const notifications = this.notifications().filter(
-      notification => notification.repository.full_name === item,
+      notification => notification.repository.full_name === item
     );
     const isFirstItem = this.getSortedRepos().indexOf(item) === 0;
     const isFirstTab = type === 0;
@@ -415,7 +415,7 @@ class Notifications extends Component {
                 iconAction={notificationID => markAsRead(notificationID)}
                 navigationAction={notify => this.navigateToThread(notify)}
                 navigation={this.props.navigation}
-              />,
+              />
             )}
           </ScrollView>
         </Card>
@@ -463,7 +463,7 @@ class Notifications extends Component {
                   animating={isRetrievingNotifications}
                   text={translate(
                     'notifications.main.retrievingMessage',
-                    language,
+                    language
                   )}
                   style={styles.marginSpacing}
                   center
@@ -503,5 +503,5 @@ class Notifications extends Component {
 }
 
 export const NotificationsScreen = connect(mapStateToProps, mapDispatchToProps)(
-  Notifications,
+  Notifications
 );

--- a/src/organization/organization.reducer.js
+++ b/src/organization/organization.reducer.js
@@ -24,60 +24,62 @@ const initialState = {
   organizationMembersError: '',
 };
 
-export const organizationReducer = handleActions({
-  [GET_ORG]: (state, { payload }) => {
-    return {
-      ...state,
-      organization: payload,
-    };
+export const organizationReducer = handleActions(
+  {
+    [GET_ORG]: (state, { payload }) => {
+      return {
+        ...state,
+        organization: payload,
+      };
+    },
+    [GET_ORG_LOADING]: (state, { payload }) => {
+      return {
+        ...state,
+        isPendingOrg: payload,
+      };
+    },
+    [GET_ORG_ERROR]: (state, { payload }) => {
+      return {
+        ...state,
+        organizationError: payload,
+      };
+    },
+    [GET_ORG_REPOS]: (state, { payload }) => {
+      return {
+        ...state,
+        repositories: payload,
+      };
+    },
+    [GET_ORG_REPOS_LOADING]: (state, { payload }) => {
+      return {
+        ...state,
+        isPendingRepos: payload,
+      };
+    },
+    [GET_ORG_REPOS_ERROR]: (state, { payload }) => {
+      return {
+        ...state,
+        organizationRepositoriesError: payload,
+      };
+    },
+    [GET_ORG_MEMBERS]: (state, { payload }) => {
+      return {
+        ...state,
+        members: payload,
+      };
+    },
+    [GET_ORG_MEMBERS_LOADING]: (state, { payload }) => {
+      return {
+        ...state,
+        isPendingMembers: payload,
+      };
+    },
+    [GET_ORG_MEMBERS_ERROR]: (state, { payload }) => {
+      return {
+        ...state,
+        organizationMembersError: payload,
+      };
+    },
   },
-  [GET_ORG_LOADING]: (state, { payload }) => {
-    return {
-      ...state,
-      isPendingOrg: payload,
-    };
-  },
-  [GET_ORG_ERROR]: (state, { payload }) => {
-    return {
-      ...state,
-      organizationError: payload,
-    };
-  },
-  [GET_ORG_REPOS]: (state, { payload }) => {
-    return {
-      ...state,
-      repositories: payload,
-    };
-  },
-  [GET_ORG_REPOS_LOADING]: (state, { payload }) => {
-    return {
-      ...state,
-      isPendingRepos: payload,
-    };
-  },
-  [GET_ORG_REPOS_ERROR]: (state, { payload }) => {
-    return {
-      ...state,
-      organizationRepositoriesError: payload,
-    };
-  },
-  [GET_ORG_MEMBERS]: (state, { payload }) => {
-    return {
-      ...state,
-      members: payload,
-    };
-  },
-  [GET_ORG_MEMBERS_LOADING]: (state, { payload }) => {
-    return {
-      ...state,
-      isPendingMembers: payload,
-    };
-  },
-  [GET_ORG_MEMBERS_ERROR]: (state, { payload }) => {
-    return {
-      ...state,
-      organizationMembersError: payload,
-    };
-  },
-}, initialState);
-
+  initialState
+);

--- a/src/organization/screens/organization-profile.screen.js
+++ b/src/organization/screens/organization-profile.screen.js
@@ -129,7 +129,7 @@ class OrganizationProfile extends Component {
     return (
       <ViewContainer>
         <ParallaxScroll
-          renderContent={() => (
+          renderContent={() =>
             <UserProfile
               type="org"
               initialUser={initialOrganization}
@@ -139,8 +139,7 @@ class OrganizationProfile extends Component {
                   : initialOrganization
               }
               navigation={navigation}
-            />
-          )}
+            />}
           refreshControl={
             <RefreshControl
               onRefresh={this.getOrgData}
@@ -153,39 +152,32 @@ class OrganizationProfile extends Component {
           showMenu
           menuAction={() => this.showMenuActionSheet()}
         >
-          {isPendingMembers && (
+          {isPendingMembers &&
             <LoadingMembersList
               title={translate('organization.main.membersTitle', language)}
-            />
-          )}
+            />}
 
-          {!isPendingMembers && (
+          {!isPendingMembers &&
             <MembersList
               title={translate('organization.main.membersTitle', language)}
               members={members}
               navigation={navigation}
-            />
-          )}
+            />}
 
           {!!organization.description &&
-            organization.description !== '' && (
-              <SectionList
-                title={translate(
-                  'organization.main.descriptionTitle',
-                  language
-                )}
-              >
-                <ListItem
-                  subtitle={emojifyText(organization.description)}
-                  subtitleStyle={styles.listSubTitle}
-                  hideChevron
-                />
-              </SectionList>
-            )}
+            organization.description !== '' &&
+            <SectionList
+              title={translate('organization.main.descriptionTitle', language)}
+            >
+              <ListItem
+                subtitle={emojifyText(organization.description)}
+                subtitleStyle={styles.listSubTitle}
+                hideChevron
+              />
+            </SectionList>}
 
-          {!isPendingOrg && (
-            <EntityInfo entity={organization} navigation={navigation} />
-          )}
+          {!isPendingOrg &&
+            <EntityInfo entity={organization} navigation={navigation} />}
         </ParallaxScroll>
 
         <ActionSheet

--- a/src/repository/screens/read-me.screen.js
+++ b/src/repository/screens/read-me.screen.js
@@ -100,25 +100,22 @@ class ReadMe extends Component {
 
     return (
       <ViewContainer>
-        {isPendingReadMe && (
-          <LoadingContainer animating={isPendingReadMe} center />
-        )}
+        {isPendingReadMe &&
+          <LoadingContainer animating={isPendingReadMe} center />}
         {!isPendingReadMe &&
-          !noReadMe && (
-            <MarkdownWebView
-              html={readMe}
-              baseUrl={`${this.props.navigation.state.params.repository
-                .html_url}/raw/master/`}
-            />
-          )}
+          !noReadMe &&
+          <MarkdownWebView
+            html={readMe}
+            baseUrl={`${this.props.navigation.state.params.repository
+              .html_url}/raw/master/`}
+          />}
         {!isPendingReadMe &&
-          noReadMe && (
-            <View style={styles.textContainer}>
-              <Text style={styles.noReadMeTitle}>
-                {translate('repository.readMe.noReadMeFound', language)}
-              </Text>
-            </View>
-          )}
+          noReadMe &&
+          <View style={styles.textContainer}>
+            <Text style={styles.noReadMeTitle}>
+              {translate('repository.readMe.noReadMeFound', language)}
+            </Text>
+          </View>}
 
         <ActionSheet
           ref={o => {

--- a/src/repository/screens/repository.screen.js
+++ b/src/repository/screens/repository.screen.js
@@ -280,43 +280,39 @@ class Repository extends Component {
         >
           {initalRepository &&
             !initalRepository.owner &&
-            isPendingRepository && (
-              <SectionList
-                title={translate('repository.main.ownerTitle', language)}
-              >
-                <LoadingUserListItem />
-              </SectionList>
-            )}
+            isPendingRepository &&
+            <SectionList
+              title={translate('repository.main.ownerTitle', language)}
+            >
+              <LoadingUserListItem />
+            </SectionList>}
 
           {!(initalRepository && initalRepository.owner) &&
             (repository && repository.owner) &&
-            !isPendingRepository && (
-              <SectionList
-                title={translate('repository.main.ownerTitle', language)}
-              >
-                <UserListItem user={repository.owner} navigation={navigation} />
-              </SectionList>
-            )}
+            !isPendingRepository &&
+            <SectionList
+              title={translate('repository.main.ownerTitle', language)}
+            >
+              <UserListItem user={repository.owner} navigation={navigation} />
+            </SectionList>}
 
           {initalRepository &&
-            initalRepository.owner && (
-              <SectionList
-                title={translate('repository.main.ownerTitle', language)}
-              >
-                <UserListItem
-                  user={initalRepository.owner}
-                  navigation={navigation}
-                />
-              </SectionList>
-            )}
-
-          {(isPendingRepository || isPendingContributors) && (
-              <LoadingMembersList
-                title={translate('repository.main.contributorsTitle', language)}
+            initalRepository.owner &&
+            <SectionList
+              title={translate('repository.main.ownerTitle', language)}
+            >
+              <UserListItem
+                user={initalRepository.owner}
+                navigation={navigation}
               />
-            )}
+            </SectionList>}
 
-          {!isPendingContributors && (
+          {(isPendingRepository || isPendingContributors) &&
+            <LoadingMembersList
+              title={translate('repository.main.contributorsTitle', language)}
+            />}
+
+          {!isPendingContributors &&
             <MembersList
               title={translate('repository.main.contributorsTitle', language)}
               members={contributors}
@@ -325,13 +321,12 @@ class Repository extends Component {
                 language
               )}
               navigation={navigation}
-            />
-          )}
+            />}
 
           <SectionList
             title={translate('repository.main.sourceTitle', language)}
           >
-            {showReadMe && (
+            {showReadMe &&
               <ListItem
                 title={translate('repository.main.readMe', language)}
                 leftIcon={{
@@ -345,8 +340,7 @@ class Repository extends Component {
                     repository,
                   })}
                 underlayColor={colors.greyLight}
-              />
-            )}
+              />}
             <ListItem
               title={translate('repository.main.viewSource', language)}
               titleStyle={styles.listTitle}
@@ -365,49 +359,48 @@ class Repository extends Component {
           </SectionList>
 
           {!repository.fork &&
-            repository.has_issues && (
-              <SectionList
-                loading={isPendingIssues}
-                title={translate('repository.main.issuesTitle', language)}
-                noItems={openIssues.length === 0}
-                noItemsMessage={
-                  pureIssues.length === 0
-                    ? translate('repository.main.noIssuesMessage', language)
-                    : translate('repository.main.noOpenIssuesMessage', language)
+            repository.has_issues &&
+            <SectionList
+              loading={isPendingIssues}
+              title={translate('repository.main.issuesTitle', language)}
+              noItems={openIssues.length === 0}
+              noItemsMessage={
+                pureIssues.length === 0
+                  ? translate('repository.main.noIssuesMessage', language)
+                  : translate('repository.main.noOpenIssuesMessage', language)
+              }
+              showButton
+              buttonTitle={
+                pureIssues.length > 0
+                  ? translate('repository.main.viewAllButton', language)
+                  : translate('repository.main.newIssueButton', language)
+              }
+              buttonAction={() => {
+                if (pureIssues.length > 0) {
+                  navigation.navigate('IssueList', {
+                    title: translate('repository.issueList.title', language),
+                    type: 'issue',
+                    issues: pureIssues,
+                  });
+                } else {
+                  navigation.navigate('NewIssue', {
+                    title: translate('issue.newIssue.title', language),
+                  });
                 }
-                showButton
-                buttonTitle={
-                  pureIssues.length > 0
-                    ? translate('repository.main.viewAllButton', language)
-                    : translate('repository.main.newIssueButton', language)
-                }
-                buttonAction={() => {
-                  if (pureIssues.length > 0) {
-                    navigation.navigate('IssueList', {
-                      title: translate('repository.issueList.title', language),
-                      type: 'issue',
-                      issues: pureIssues,
-                    });
-                  } else {
-                    navigation.navigate('NewIssue', {
-                      title: translate('issue.newIssue.title', language),
-                    });
-                  }
-                }}
-              >
-                {openIssues
-                  .slice(0, 3)
-                  .map(item => (
-                    <IssueListItem
-                      key={item.id}
-                      type="issue"
-                      issue={item}
-                      navigation={navigation}
-                      language={language}
-                    />
-                  ))}
-              </SectionList>
-            )}
+              }}
+            >
+              {openIssues
+                .slice(0, 3)
+                .map(item =>
+                  <IssueListItem
+                    key={item.id}
+                    type="issue"
+                    issue={item}
+                    navigation={navigation}
+                    language={language}
+                  />
+                )}
+            </SectionList>}
 
           <SectionList
             loading={isPendingIssues}
@@ -432,7 +425,7 @@ class Repository extends Component {
           >
             {openPulls
               .slice(0, 3)
-              .map(item => (
+              .map(item =>
                 <IssueListItem
                   key={item.id}
                   type="pull"
@@ -440,7 +433,7 @@ class Repository extends Component {
                   navigation={navigation}
                   language={language}
                 />
-              ))}
+              )}
           </SectionList>
         </ParallaxScroll>
 

--- a/src/user/screens/profile.screen.js
+++ b/src/user/screens/profile.screen.js
@@ -168,7 +168,7 @@ class Profile extends Component {
     return (
       <ViewContainer>
         <ParallaxScroll
-          renderContent={() => (
+          renderContent={() =>
             <UserProfile
               type="user"
               initialUser={initialUser}
@@ -178,8 +178,7 @@ class Profile extends Component {
               user={!isPending ? user : {}}
               language={language}
               navigation={navigation}
-            />
-          )}
+            />}
           refreshControl={
             <RefreshControl
               refreshing={refreshing || isPending}
@@ -196,45 +195,42 @@ class Profile extends Component {
           navigateBack
           navigation={navigation}
         >
-          {isPending && (
+          {isPending &&
             <ActivityIndicator
               animating={isPending}
               style={{ height: Dimensions.get('window').height / 3 }}
               size="large"
-            />
-          )}
+            />}
 
           {!isPending &&
-            initialUser.login === user.login && (
-              <View>
-                {!!user.bio &&
-                  user.bio !== '' && (
-                    <SectionList title={translate('common.bio', language)}>
-                      <ListItem
-                        subtitle={emojifyText(user.bio)}
-                        subtitleStyle={styles.listSubTitle}
-                        hideChevron
-                      />
-                    </SectionList>
-                  )}
+            initialUser.login === user.login &&
+            <View>
+              {!!user.bio &&
+                user.bio !== '' &&
+                <SectionList title={translate('common.bio', language)}>
+                  <ListItem
+                    subtitle={emojifyText(user.bio)}
+                    subtitleStyle={styles.listSubTitle}
+                    hideChevron
+                  />
+                </SectionList>}
 
-                <EntityInfo entity={user} orgs={orgs} navigation={navigation} />
+              <EntityInfo entity={user} orgs={orgs} navigation={navigation} />
 
-                <SectionList
-                  title={translate('common.orgs', language)}
-                  noItems={orgs.length === 0}
-                  noItemsMessage={translate('common.noOrgsMessage', language)}
-                >
-                  {orgs.map(item => (
-                    <UserListItem
-                      key={item.id}
-                      user={item}
-                      navigation={navigation}
-                    />
-                  ))}
-                </SectionList>
-              </View>
-            )}
+              <SectionList
+                title={translate('common.orgs', language)}
+                noItems={orgs.length === 0}
+                noItemsMessage={translate('common.noOrgsMessage', language)}
+              >
+                {orgs.map(item =>
+                  <UserListItem
+                    key={item.id}
+                    user={item}
+                    navigation={navigation}
+                  />
+                )}
+              </SectionList>
+            </View>}
         </ParallaxScroll>
 
         <ActionSheet

--- a/src/user/screens/repository-list.screen.js
+++ b/src/user/screens/repository-list.screen.js
@@ -28,7 +28,7 @@ const mapDispatchToProps = dispatch =>
       getRepositories,
       searchUserRepos,
     },
-    dispatch,
+    dispatch
   );
 
 const styles = StyleSheet.create({
@@ -152,7 +152,7 @@ class RepositoryList extends Component {
 
           {loading &&
             [...Array(searchStart ? repoCount : 10)].map(
-              (item, index) => <LoadingRepositoryListItem key={index} />, // eslint-disable-line react/no-array-index-key
+              (item, index) => <LoadingRepositoryListItem key={index} /> // eslint-disable-line react/no-array-index-key
             )}
 
           {!loading &&
@@ -177,5 +177,5 @@ class RepositoryList extends Component {
 
 export const RepositoryListScreen = connect(
   mapStateToProps,
-  mapDispatchToProps,
+  mapDispatchToProps
 )(RepositoryList);


### PR DESCRIPTION
Under normal conditions, prettier is only run on the lines of code that are changes in that commit. This cleans up all the code that doesn't currently conform to our prettier configuration, making the style completely consistent across all files again (and fixes the failing CI).

The command to run this cleanup yourself:

```bash
$ prettier --single-quote --trailing-comma es5 --write "**/*.js"
$ # or
$ yarn prettier
```