### PR TITLE
feat: Flash members list when it's scrollable

### DIFF
--- a/src/components/members.component.js
+++ b/src/components/members.component.js
@@ -90,7 +90,19 @@ const MembersListComponent = ({
     <FlatList
       style={styles.flatList}
       data={members}
-      showsHorizontalScrollIndicator={false}
+      ref={ref => {
+        this.listRef = ref;
+      }}
+      showsHorizontalScrollIndicator
+      onContentSizeChange={() => {
+        const list = this.listRef;
+
+        list.flashScrollIndicators();
+        setTimeout(
+          () => list.setNativeProps({ showsHorizontalScrollIndicator: false }),
+          1000
+        );
+      }}
       renderItem={({ item }) => (
         <TouchableHighlight
           onPress={() => {


### PR DESCRIPTION
Addresses #492 by flashing the FlatList. Scrolling indicator is disabled afterward.

![gif](http://g.recordit.co/ISRhBT5G64.gif)