### PR TITLE
fix(ux): Add back button for AuthProfileScreen

### DIFF
--- a/src/auth/screens/auth-profile.screen.js
+++ b/src/auth/screens/auth-profile.screen.js
@@ -113,6 +113,8 @@ class AuthProfile extends Component {
       hasInitialUser,
     } = this.props;
 
+    const hasBackButton = navigation.state.routeName === 'AuthProfile';
+
     const isPending = isPendingUser || isPendingOrgs;
 
     return (
@@ -135,6 +137,8 @@ class AuthProfile extends Component {
             />
           }
           stickyTitle={user.login}
+          navigateBack={hasBackButton}
+          navigation={navigation}
           showMenu
           menuIcon="gear"
           menuAction={() =>
@@ -163,7 +167,12 @@ class AuthProfile extends Component {
             )}
 
           {!isPending && (
-            <EntityInfo entity={user} orgs={orgs} navigation={navigation} locale={locale} />
+            <EntityInfo
+              entity={user}
+              orgs={orgs}
+              navigation={navigation}
+              locale={locale}
+            />
           )}
 
           {!isPending && (


### PR DESCRIPTION
Hey everyone, one friend has reported that if we navigate to an AuthProfile in the middle of some StackNavigator will be locked on the screen because the back button doesn't appear, so this pull request fixes it.

### Before

<img height="400" src="https://user-images.githubusercontent.com/1559013/31753648-51634e06-b468-11e7-961b-58d96222d9ed.gif">

### After

<img height="400" src="https://user-images.githubusercontent.com/1559013/31753647-50397942-b468-11e7-897d-75eb89859ef7.gif">
