### PR TITLE
chore: fix `yarn run link`

### DIFF
--- a/ios/GitPoint.xcodeproj/project.pbxproj
+++ b/ios/GitPoint.xcodeproj/project.pbxproj
@@ -5,7 +5,6 @@
 	};
 	objectVersion = 46;
 	objects = {
-
 /* Begin PBXBuildFile section */
 		00C302E51ABCBA2D00DB3ED1 /* libRCTActionSheet.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302AC1ABCB8CE00DB3ED1 /* libRCTActionSheet.a */; };
 		00C302E71ABCBA2D00DB3ED1 /* libRCTGeolocation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302BA1ABCB90400DB3ED1 /* libRCTGeolocation.a */; };

--- a/ios/GitPoint.xcodeproj/project.pbxproj
+++ b/ios/GitPoint.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		B58367881AB44EC4944D4698 /* Nunito-Italic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = E37A1EB69E2D4FD7B138343D /* Nunito-Italic.ttf */; };
 		B66611A59CDF49A19C845B57 /* Nunito-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 78A9FAE6B34B4FAC9F27CBC3 /* Nunito-Regular.ttf */; };
 		B8D599F61D2A4797A2F71CAA /* libRNVectorIcons.a in Frameworks */ = {isa = PBXBuildFile; fileRef = AFDBB5669CAB4C5C8215B571 /* libRNVectorIcons.a */; };
+		D2C2FCD70676466EA8E466D6 /* Menlo.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 18487F5E165143648CF0950E /* Menlo.ttf */; };
 		DC5C35E71E37AD1800F3F526 /* FontAwesome.ttf in Resources */ = {isa = PBXBuildFile; fileRef = DC5C35DD1E37AD1800F3F526 /* FontAwesome.ttf */; };
 		EB0F176BE52B4561B9FF07AB /* libReactNativeConfig.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D7043BDB577E427391ECFBB0 /* libReactNativeConfig.a */; };
 /* End PBXBuildFile section */
@@ -343,6 +344,7 @@
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = GitPoint/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = GitPoint/main.m; sourceTree = "<group>"; };
 		146833FF1AC3E56700842450 /* React.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = React.xcodeproj; path = "../node_modules/react-native/React/React.xcodeproj"; sourceTree = "<group>"; };
+		18487F5E165143648CF0950E /* Menlo.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Menlo.ttf; path = ../src/assets/fonts/Menlo.ttf; sourceTree = "<group>"; };
 		1ABB0D8AB2424B1595DABB16 /* libRNPhotoView.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRNPhotoView.a; sourceTree = "<group>"; };
 		24C757CE6CB049658C31ED0E /* Nunito-Bold.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Nunito-Bold.ttf"; path = "../src/assets/fonts/Nunito-Bold.ttf"; sourceTree = "<group>"; };
 		27CFE4061F920B7700951EF2 /* MaterialIcons.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = MaterialIcons.ttf; sourceTree = "<group>"; };
@@ -557,6 +559,7 @@
 				ED1B22A89E134AA89E251577 /* Nunito-Light.ttf */,
 				78A9FAE6B34B4FAC9F27CBC3 /* Nunito-Regular.ttf */,
 				FBD0F4CBD299403498005E08 /* Nunito-SemiBold.ttf */,
+				18487F5E165143648CF0950E /* Menlo.ttf */,
 			);
 			name = Resources;
 			sourceTree = "<group>";
@@ -1233,6 +1236,7 @@
 				5DC6C311356B4973AE2599BF /* Nunito-Light.ttf in Resources */,
 				B66611A59CDF49A19C845B57 /* Nunito-Regular.ttf in Resources */,
 				4A0E0CE9909244398A873436 /* Nunito-SemiBold.ttf in Resources */,
+				D2C2FCD70676466EA8E466D6 /* Menlo.ttf in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/GitPoint/Info.plist
+++ b/ios/GitPoint/Info.plist
@@ -49,7 +49,7 @@
 		</dict>
 	</dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string></string>
+	<string/>
 	<key>UIAppFonts</key>
 	<array>
 		<string>FontAwesome.ttf</string>
@@ -60,6 +60,7 @@
 		<string>Nunito-Light.ttf</string>
 		<string>Nunito-Regular.ttf</string>
 		<string>Nunito-SemiBold.ttf</string>
+		<string>Menlo.ttf</string>
 	</array>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>

--- a/rn-cli.config.js
+++ b/rn-cli.config.js
@@ -1,0 +1,18 @@
+const defaultConfig = require('react-native/local-cli/core/default.config.js');
+
+const config = {
+  getDependencyConfig(packageName) {
+    if (packageName === 'react-native-vector-icons') {
+      // we do not need link all fonts from it, #402
+      return {
+        assets: [],
+        commands: {},
+        params: [],
+      };
+    }
+
+    return defaultConfig.getDependencyConfig(packageName);
+  },
+};
+
+module.exports = config;

--- a/rn-cli.config.js
+++ b/rn-cli.config.js
@@ -1,17 +1,37 @@
-const defaultConfig = require('react-native/local-cli/core/default.config.js');
+// Inspired by react-native/local-cli/core/index.js
+
+const android = require('react-native/local-cli/core/android');
+const ios = require('react-native/local-cli/core/ios');
+const windows = require('react-native/local-cli/core/windows');
+const findAssets = require('react-native/local-cli/core/findAssets');
+const wrapCommands = require('react-native/local-cli/core/wrapCommands');
+
+const path = require('path');
+
+const getRNPMConfig = folder =>
+  // eslint-disable-next-line import/no-dynamic-require
+  require(path.join(folder, './package.json')).rnpm || {};
 
 const config = {
   getDependencyConfig(packageName) {
+    const folder = path.join(process.cwd(), 'node_modules', packageName);
+    const rnpm = getRNPMConfig(
+      path.join(process.cwd(), 'node_modules', packageName)
+    );
+
     if (packageName === 'react-native-vector-icons') {
       // we do not need link all fonts from it, #402
-      return {
-        assets: [],
-        commands: {},
-        params: [],
-      };
+      rnpm.assets = [];
     }
 
-    return defaultConfig.getDependencyConfig(packageName);
+    return Object.assign({}, rnpm, {
+      ios: ios.dependencyConfig(folder, rnpm.ios || {}),
+      android: android.dependencyConfig(folder, rnpm.android || {}),
+      windows: windows.dependencyConfig(folder, rnpm.windows || {}),
+      assets: findAssets(folder, rnpm.assets),
+      commands: wrapCommands(rnpm.commands),
+      params: rnpm.params || [],
+    });
   },
 };
 


### PR DESCRIPTION
With `rn-cli.config.js`, we can ignore assets that `react-native-vector-icons` defines in [its rnpm config](https://github.com/oblador/react-native-vector-icons/blob/master/package.json#L57). So that `react-native link` will not link those assets into our project again.

I removed some useless fonts for iOS in #475, but @housseindjirdeh and @machour pointed that `yarn run link`(which runs `react-native link` in fact) will add them back. It is really hard to find a thorough document about `react-native link`. Fortunately, I find the way to solve this problem after dig into RN source codes[[1](https://github.com/facebook/react-native/blob/master/local-cli/link/link.js#L198), [2](https://github.com/facebook/react-native/blob/master/local-cli/link/getDependencyConfig.js#L9)].

By the way, I added the font `Menlo` back. It doesn't belongs to `react-native-vector-icons`. Sorry for removed by mistake.