### PR TITLE
fix: Remove undefined var & fix typo

### DIFF
--- a/src/components/parallax-scroll.component.js
+++ b/src/components/parallax-scroll.component.js
@@ -34,13 +34,11 @@ const styles = StyleSheet.create({
   background: {
     position: 'absolute',
     top: 0,
-    width: window.width,
     backgroundColor: colors.primaryDark,
   },
   stickySection: {
     height: STICKY_HEADER_HEIGHT,
     backgroundColor: colors.primaryDark,
-    width: window.width,
     alignItems: 'center',
     justifyContent: 'flex-end',
   },
@@ -78,13 +76,13 @@ export class ParallaxScroll extends Component {
   }
 
   getParallaxHeaderHeight = (window = Dimensions.get('window')) => {
-    let devider = 2;
+    let divider = 2;
 
     if (window.width > window.height) {
-      devider = Platform.OS === 'ios' ? 1.2 : 1.4;
+      divider = Platform.OS === 'ios' ? 1.2 : 1.4;
     }
 
-    return window.height / devider;
+    return window.height / divider;
   };
 
   dimensionsDidChange = ({ window }) => {


### PR DESCRIPTION
`window` was used without ever being defined & setting `width` is not needed (tested on iOS & Android while changing device orientation)

This only causes an error with RN 0.49.3, really curious Oo.