### PR TITLE
fix(ux): Add Back button event on ImageZoom component

### DIFF
--- a/src/components/image-zoom.component.js
+++ b/src/components/image-zoom.component.js
@@ -58,7 +58,7 @@ export class ImageZoom extends Component {
 
     if (this.state.imgZoom) {
       return (
-        <Modal animationType={'fade'} onRequestClose={() => null}>
+        <Modal animationType={'fade'} onRequestClose={() => this.closeModal()}>
           <View style={styles.modalContainer}>
             <PhotoView
               resizeMode={'contain'}


### PR DESCRIPTION
Hey, Jouderian here doing another small PR 😄 

I've noticed that back button in ImageZoom component was doing nothing, but in Android is quite common uses back button action to close a modal.

### Before

![beforemodal](https://user-images.githubusercontent.com/1559013/31803425-05dc2742-b52a-11e7-87f7-1d1de53f4ef2.gif)

### After

![aftermodal](https://user-images.githubusercontent.com/1559013/31803431-0b89ef80-b52a-11e7-932f-6ec183b76ef2.gif)

