### PR TITLE
fix(issue): Fix pull request related fields are not reset

### DIFF
--- a/src/issue/issue.reducer.js
+++ b/src/issue/issue.reducer.js
@@ -271,6 +271,9 @@ export const issueReducer = (state = initialState, action = {}) => {
         ...state,
         issue: action.payload,
         isPendingIssue: false,
+        pr: initialState.pr,
+        diff: initialState.diff,
+        isMerged: initialState.isMerged,
       };
     case GET_ISSUE_FROM_URL.ERROR:
       return {


### PR DESCRIPTION
If you try to visit an opened issue after a merged PR, there will be no `Close Issue` button in issue settings screen. [Related codes](https://github.com/gitpoint/git-point/blob/master/src/issue/screens/issue-settings.screen.js#L266).

The reason is that pull request related fields in the store are not reset. I have to admit that resetting these field in the handle of `GET_ISSUE_FROM_URL.SUCCESS` is a little wired. But before we have refactored our redux store, it is hard to find a more elegant way.