### PR TITLE
fix(warning): Fix the key extractor of issue screen

### DIFF
--- a/src/issue/screens/issue.screen.js
+++ b/src/issue/screens/issue.screen.js
@@ -274,8 +274,8 @@ class Issue extends Component {
     });
   };
 
-  keyExtractor = item => {
-    return item.id;
+  keyExtractor = (item, index) => {
+    return index;
   };
 
   renderHeader = () => {
@@ -366,44 +366,46 @@ class Issue extends Component {
 
     return (
       <ViewContainer>
-        {isShowLoadingContainer &&
-          <LoadingContainer animating={isShowLoadingContainer} center />}
+        {isShowLoadingContainer && (
+          <LoadingContainer animating={isShowLoadingContainer} center />
+        )}
 
         {!isPendingComments &&
           !isPendingIssue &&
-          issue &&
-          <KeyboardAvoidingView
-            style={{ flex: 1 }}
-            behavior={'padding'}
-            keyboardVerticalOffset={Platform.select({
-              ios: 65,
-              android: -200,
-            })}
-          >
-            <FlatList
-              ref={ref => {
-                this.commentsList = ref;
-              }}
-              refreshing={isLoadingData}
-              onRefresh={this.getIssueInformation}
-              contentContainerStyle={{ flexGrow: 1 }}
-              ListHeaderComponent={this.renderHeader}
-              removeClippedSubviews={false}
-              data={conversation}
-              keyExtractor={this.keyExtractor}
-              renderItem={this.renderItem}
-            />
+          issue && (
+            <KeyboardAvoidingView
+              style={{ flex: 1 }}
+              behavior={'padding'}
+              keyboardVerticalOffset={Platform.select({
+                ios: 65,
+                android: -200,
+              })}
+            >
+              <FlatList
+                ref={ref => {
+                  this.commentsList = ref;
+                }}
+                refreshing={isLoadingData}
+                onRefresh={this.getIssueInformation}
+                contentContainerStyle={{ flexGrow: 1 }}
+                ListHeaderComponent={this.renderHeader}
+                removeClippedSubviews={false}
+                data={conversation}
+                keyExtractor={this.keyExtractor}
+                renderItem={this.renderItem}
+              />
 
-            <CommentInput
-              users={fullUsers}
-              userHasPushPermission={
-                navigation.state.params.userHasPushPermission
-              }
-              issueLocked={issue.locked}
-              locale={locale}
-              onSubmit={this.postComment}
-            />
-          </KeyboardAvoidingView>}
+              <CommentInput
+                users={fullUsers}
+                userHasPushPermission={
+                  navigation.state.params.userHasPushPermission
+                }
+                issueLocked={issue.locked}
+                locale={locale}
+                onSubmit={this.postComment}
+              />
+            </KeyboardAvoidingView>
+          )}
 
         <ActionSheet
           ref={o => {


### PR DESCRIPTION
Before #438, data of `FlatList` only contained issue and comments. But now events are included, which have no field calls `id`. (I changed 2 lines and prettier did the rest. 😱 )

```
const conversation = !isPendingComments
  ? [issue, ...comments, ...events].sort(compareCreatedAt)
  : [];
```