### PR TITLE
fix: fix section list button height

### DIFF
--- a/src/components/section-list.component.js
+++ b/src/components/section-list.component.js
@@ -42,7 +42,6 @@ const styles = StyleSheet.create({
     borderRadius: 3,
     paddingVertical: 5,
     paddingHorizontal: 10,
-    marginTop: -8,
   },
   list: {
     marginTop: 0,


### PR DESCRIPTION
This problem is only happening on Android.

### Before

<img width="339" alt="screen shot 2017-10-21 at 11 49 05" src="https://user-images.githubusercontent.com/1559013/31852873-0ef1c800-b656-11e7-98ed-e1cefb0734ff.png">

### After

<img width="333" alt="screen shot 2017-10-21 at 11 47 50" src="https://user-images.githubusercontent.com/1559013/31852876-16dc0940-b656-11e7-8bbd-9068db601866.png">
