### PR TITLE
chore(*): Remove package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ local.properties
 node_modules/
 npm-debug.log
 yarn-error.log
+package-lock.json
 
 # BUCK
 buck-out/


### PR DESCRIPTION
I've seen a couple of PRs that include `package-lock.json` file. Because we're using yarn this file won't be necessary.