### PR TITLE
chore: remove unneeded install step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ cache:
     - node_modules
 node_js:
   - 7
-before_script:
-  - yarn
 script:
   - yarn run test
   - yarn run eslint


### PR DESCRIPTION
`yarn` is run by default in the install step.