### PR TITLE
test: added search reducer tests

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -12,19 +12,20 @@
           "./src"
         ],
         "alias": {
-          "components": "components",
-          "search": "search",
-          "notifications": "notifications",
-          "auth": "auth",
-          "user": "user",
-          "organization": "organization",
-          "repository": "repository",
-          "issue": "issue",
           "api": "api",
+          "auth": "auth",
+          "components": "components",
           "config": "config",
-          "utils": "utils",
+          "issue": "issue",
           "locale": "locale",
-          "package.json": "./package.json"
+          "notifications": "notifications",
+          "organization": "organization",
+          "package.json": "./package.json",
+          "repository": "repository",
+          "search": "search",
+          "testData": "./__tests__/data",
+          "user": "user",
+          "utils": "utils"
         }
       }
     ],

--- a/.eslintrc
+++ b/.eslintrc
@@ -26,18 +26,18 @@
           "./src"
         ],
         "alias": {
-          "components": "components",
-          "search": "search",
-          "notifications": "notifications",
+          "api": "api",
           "auth": "auth",
-          "user": "user",
+          "components": "components",
+          "config": "config",
+          "issue": "issue",
+          "locale": "locale",
+          "notifications": "notifications",
           "organization": "organization",
           "repository": "repository",
-          "issue": "issue",
-          "api": "api",
-          "config": "config",
-          "utils": "utils",
-          "locale": "locale"
+          "search": "search",
+          "testData": "./__tests__/data",
+          "utils": "utils"
         }
       }
     }
@@ -152,7 +152,7 @@
           "/^(get|set)(?!(InitialState$|DefaultProps$|ChildContext$)).+$/",
           "everything-else",
           "/^render.+$/",
-          "render",
+          "render"
         ],
         "groups": {
           "lifecycle": [

--- a/__tests__/data/api/error.js
+++ b/__tests__/data/api/error.js
@@ -1,0 +1,5 @@
+export const authError = {
+  message: 'Requires authentication',
+  documentation_url:
+    'https://developer.github.com/v3/activity/notifications/#list-your-notifications',
+};

--- a/__tests__/data/api/search.js
+++ b/__tests__/data/api/search.js
@@ -1,0 +1,64 @@
+export const repos = {
+  total_count: 40,
+  incomplete_results: false,
+  items: [
+    {
+      id: 3081286,
+      name: 'Tetris',
+      full_name: 'dtrupenn/Tetris',
+      owner: {
+        login: 'dtrupenn',
+        id: 872147,
+        avatar_url:
+          'https://secure.gravatar.com/avatar/e7956084e75f239de85d3a31bc172ace?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png',
+        gravatar_id: '',
+        url: 'https://api.github.com/users/dtrupenn',
+        received_events_url:
+          'https://api.github.com/users/dtrupenn/received_events',
+        type: 'User',
+      },
+      private: false,
+      html_url: 'https://github.com/dtrupenn/Tetris',
+      description: 'A C implementation of Tetris using Pennsim through LC4',
+      fork: false,
+      url: 'https://api.github.com/repos/dtrupenn/Tetris',
+      created_at: '2012-01-01T00:31:50Z',
+      updated_at: '2013-01-05T17:58:47Z',
+      pushed_at: '2012-01-01T00:37:02Z',
+      homepage: '',
+      size: 524,
+      stargazers_count: 1,
+      watchers_count: 1,
+      language: 'Assembly',
+      forks_count: 0,
+      open_issues_count: 0,
+      master_branch: 'master',
+      default_branch: 'master',
+      score: 10.309712,
+    },
+  ],
+};
+
+export const users = {
+  total_count: 12,
+  incomplete_results: false,
+  items: [
+    {
+      login: 'mojombo',
+      id: 1,
+      avatar_url:
+        'https://secure.gravatar.com/avatar/25c7c18223fb42a4c6ae1c8db6f50f9b?d=https://a248.e.akamai.net/assets.github.com%2Fimages%2Fgravatars%2Fgravatar-user-420.png',
+      gravatar_id: '',
+      url: 'https://api.github.com/users/mojombo',
+      html_url: 'https://github.com/mojombo',
+      followers_url: 'https://api.github.com/users/mojombo/followers',
+      subscriptions_url: 'https://api.github.com/users/mojombo/subscriptions',
+      organizations_url: 'https://api.github.com/users/mojombo/orgs',
+      repos_url: 'https://api.github.com/users/mojombo/repos',
+      received_events_url:
+        'https://api.github.com/users/mojombo/received_events',
+      type: 'User',
+      score: 105.47857,
+    },
+  ],
+};

--- a/__tests__/tests/reducers/search.reducer.js
+++ b/__tests__/tests/reducers/search.reducer.js
@@ -1,0 +1,103 @@
+import React from 'react';
+import { searchReducer, initialState } from 'search/search.reducer';
+import { SEARCH_REPOS, SEARCH_USERS } from 'search/search.type';
+import { repos, users } from 'testData/api/search';
+import { authError } from 'testData/api/error';
+
+describe('Search Reducer', () => {
+  it('should return the initial state', () => {
+    expect(searchReducer(undefined, {})).toEqual(initialState);
+  });
+
+  /**
+   * Search repositories.
+   */
+  it('should set repos to empty and set isPendingSearchRepos to true when SEARCH_REPOS.PENDING action is dispatched', () => {
+    const expectedState = {
+      ...initialState,
+      repos: [],
+      isPendingSearchRepos: true,
+    };
+    const action = {
+      type: SEARCH_REPOS.PENDING,
+    };
+
+    expect(searchReducer(initialState, action)).toEqual(expectedState);
+  });
+
+  it('should set repos from payload of SEARCH_REPOS.SUCCESS action and set isPendingSearchRepos to false', () => {
+    const expectedState = {
+      ...initialState,
+      repos: repos.items,
+      isPendingSearchRepos: false,
+    };
+    // The 'searchRepos' action creator dispatches this action with repos.items payload.
+    const action = {
+      type: SEARCH_REPOS.SUCCESS,
+      payload: repos.items,
+    };
+
+    expect(searchReducer(initialState, action)).toEqual(expectedState);
+  });
+
+  it('should set an error from payload of SEARCH_REPOS.ERROR action and set isPendingSearchRepos to false', () => {
+    const expectedState = {
+      ...initialState,
+      error: authError,
+      isPendingSearchRepos: false,
+    };
+    // The 'searchRepos' action creator dispatches this action with data.items payload.
+    const action = {
+      type: SEARCH_REPOS.ERROR,
+      payload: authError,
+    };
+
+    expect(searchReducer(initialState, action)).toEqual(expectedState);
+  });
+
+  /**
+   * Search users.
+   */
+  it('should set users to empty and set isPendingSearchUsers to true when SEARCH_USERS.PENDING action is dispatched', () => {
+    const expectedState = {
+      ...initialState,
+      users: [],
+      isPendingSearchUsers: true,
+    };
+    const action = {
+      type: SEARCH_USERS.PENDING,
+    };
+
+    expect(searchReducer(initialState, action)).toEqual(expectedState);
+  });
+
+  it('should set users from payload of SEARCH_USERS.SUCCESS action and set isPendingSearchUsers to false', () => {
+    const expectedState = {
+      ...initialState,
+      users: users.items,
+      isPendingSearchUsers: false,
+    };
+    // The 'searchUsers' action creator dispatches this action with data.items payload.
+    const action = {
+      type: SEARCH_USERS.SUCCESS,
+      payload: users.items,
+    };
+
+    expect(searchReducer(initialState, action)).toEqual(expectedState);
+  });
+
+  it('should set an error from payload of SEARCH_USERS.ERROR action and set isPendingSearchUsers to false', () => {
+    const expectedState = {
+      ...initialState,
+      error: authError,
+      isPendingSearchUsers: false,
+    };
+    // The 'searchRepos' action creator dispatches this action with repos.items payload.
+    const action = {
+      type: SEARCH_REPOS.ERROR,
+      payload: authError,
+    };
+
+    expect(searchReducer(initialState, action)).toEqual(expectedState);
+  });
+});

--- a/src/search/search.reducer.js
+++ b/src/search/search.reducer.js
@@ -1,6 +1,6 @@
 import { SEARCH_REPOS, SEARCH_USERS } from './search.type';
 
-const initialState = {
+export const initialState = {
   users: [],
   repos: [],
   isPendingSearchUsers: false,


### PR DESCRIPTION
Nice easy one to add tests for the search reducer.   
Includes changes to add aliases to `.babelrc` and `.eslintrc` from #567 in order to past tests as PR's may not be merged in order and obviously not being able to open PR against master here or the branch from #567 since it exists in the fork not upstream.