### PR TITLE
fix(sc): Fix by stylelint

### DIFF
--- a/src/components/code-line.component.js
+++ b/src/components/code-line.component.js
@@ -36,18 +36,18 @@ const Wrapper = styled.View`
 `;
 
 const CodeLineContainer = styled.View`
-  min-width: ${Dimensions.get('window').width - 80}
+  min-width: ${Dimensions.get('window').width - 80};
   flex: 0.85;
   background-color: ${props =>
     props.newChunk
       ? colors.codeChunkBlue
-      : addOrDelLineColors(props.change).line}
+      : addOrDelLineColors(props.change).line};
   }
 `;
 
 const CodeLineStyled = styled.Text`
-  font-family: ${styledFonts.fontCode}
-  font-size: ${normalize(11)}
+  font-family: ${styledFonts.fontCode};
+  font-size: ${normalize(11)};
   padding: 3 10;
   ${props =>
     props.newChunk &&
@@ -69,11 +69,11 @@ const LineNumbers = styled.View`
 `;
 
 const CodeLineNumber = styled.Text`
-  font-family: ${styledFonts.fontCode}
-  font-size: ${normalize(11)}
+  font-family: ${styledFonts.fontCode};
+  font-size: ${normalize(11)};
   flex: 1;
   align-items: center;
-  color: ${colors.grey}
+  color: ${colors.grey};
 `;
 
 const SyntaxHighlighterStyled = CodeLineStyled.withComponent(SyntaxHighlighter);

--- a/src/components/code-line.component.js
+++ b/src/components/code-line.component.js
@@ -42,7 +42,6 @@ const CodeLineContainer = styled.View`
     props.newChunk
       ? colors.codeChunkBlue
       : addOrDelLineColors(props.change).line};
-  }
 `;
 
 const CodeLineStyled = styled.Text`

--- a/src/components/code-line.component.js
+++ b/src/components/code-line.component.js
@@ -57,8 +57,7 @@ const CodeLineStyled = styled.Text`
 
 const LineNumbers = styled.View`
   width: 80;
-  padding-left: 10;
-  padding: 3;
+  padding: 3px;
   flex-direction: row;
   justify-content: space-between;
   background-color: ${props =>

--- a/src/components/code-line.component.js
+++ b/src/components/code-line.component.js
@@ -47,12 +47,12 @@ const CodeLineContainer = styled.View`
 const CodeLineStyled = styled.Text`
   font-family: ${styledFonts.fontCode};
   font-size: ${normalize(11)};
-  padding: 3 10;
+  padding: 3px 10px;
   ${props =>
     props.newChunk &&
     css`
       color: ${colors.grey};
-    `}
+    `};
 `;
 
 const LineNumbers = styled.View`

--- a/src/components/entity-info.component.js
+++ b/src/components/entity-info.component.js
@@ -25,7 +25,7 @@ const StyledListItem = styled(ListItem).attrs({
   },
   underlayColor: props => (props.unknown ? null : colors.greyLight),
   hideChevron: props => props.unknown,
-})``;
+});
 
 const getBlogLink = url =>
   url.substr(0, 4) === 'http' ? url : `http://${url}`;

--- a/src/components/entity-info.component.js
+++ b/src/components/entity-info.component.js
@@ -25,7 +25,7 @@ const StyledListItem = styled(ListItem).attrs({
   },
   underlayColor: props => (props.unknown ? null : colors.greyLight),
   hideChevron: props => props.unknown,
-});
+})``;
 
 const getBlogLink = url =>
   url.substr(0, 4) === 'http' ? url : `http://${url}`;

--- a/src/components/image-zoom.component.js
+++ b/src/components/image-zoom.component.js
@@ -23,8 +23,8 @@ const StyledPhotoView = styled(PhotoView).attrs({
   minimumZoomScale: 0.5,
   maximumZoomScale: 3,
 })`
-   width: ${Dimensions.get('window').width}px;
-   height: ${Dimensions.get('window').height}px;
+  width: ${Dimensions.get('window').width}px;
+  height: ${Dimensions.get('window').height}px;
 `;
 
 const CloseButton = styled.TouchableOpacity.attrs({
@@ -40,7 +40,7 @@ const CloseIcon = styled(Icon).attrs({
   size: 28,
   name: 'x',
   type: 'octicon',
-})``;
+});
 
 export class ImageZoom extends Component {
   props: {

--- a/src/components/image-zoom.component.js
+++ b/src/components/image-zoom.component.js
@@ -40,7 +40,7 @@ const CloseIcon = styled(Icon).attrs({
   size: 28,
   name: 'x',
   type: 'octicon',
-});
+})``;
 
 export class ImageZoom extends Component {
   props: {

--- a/src/components/inline-label.component.js
+++ b/src/components/inline-label.component.js
@@ -7,11 +7,9 @@ import { getFontColorByBackground } from 'utils';
 const InlineLabelText = styled.Text`
   font-size: ${normalize(10)};
   ${{ ...fonts.fontPrimarySemiBold }};
-  padding-horizontal: 5;
-  margin-top: 2;
-  margin-left: 2;
-  margin-right: 2;
-  margin-bottom: 2;
+  padding-left: 5;
+  padding-right: 5;
+  margin: 2px;
   border-width: 1;
   overflow: hidden;
   border-radius: 3;

--- a/src/components/issue-description.component.js
+++ b/src/components/issue-description.component.js
@@ -36,8 +36,8 @@ const ContainerBorderBottom = styled.View`
 `;
 
 const ListItemStyled = styled(ListItem)`
-  color: ${colors.primaryDark}
-  font-family: ${styledFonts.fontPrimarySemiBold}
+  color: ${colors.primaryDark};
+  font-family: ${styledFonts.fontPrimarySemiBold};
 `;
 
 const ListItemURL = ListItemStyled.extend`

--- a/src/components/issue-description.component.js
+++ b/src/components/issue-description.component.js
@@ -58,8 +58,7 @@ const DiffBlocksContainer = styled.View`
 `;
 
 const LabelButtonGroup = styled.View`
-  flex-wrap: wrap;
-  flex-direction: row;
+  flex-flow: row wrap;
   margin-left: 54;
   padding-bottom: 15;
 `;
@@ -74,7 +73,8 @@ const MergeButtonContainer = styled.View`
   flex-direction: row;
   justify-content: center;
   align-items: center;
-  padding-vertical: 15;
+  padding-top: 15;
+  padding-bottom: 15;
 `;
 
 export class IssueDescription extends Component {

--- a/src/components/issue-event-list-item.component.js
+++ b/src/components/issue-event-list-item.component.js
@@ -21,37 +21,29 @@ const IconStyled = styled(Icon)`
   height: 26;
   margin-left: 14;
   margin-right: 14;
-  flex-grow: 0;
-  flex-shrink: 0;
-  flex-basis: 26;
+  flex: 0 0 26px;
 `;
 
 const ContentContainer = styled.View`
   flex-direction: row;
-  flex-grow: 1;
-  flex-shrink: 1;
+  flex: 1 1;
   border-bottom-color: ${colors.greyLight};
   border-bottom-width: 1;
 `;
 
 const EventTextContainer = styled.View`
   padding-bottom: 10;
-  flex-direction: row;
-  flex-wrap: wrap;
-  flex-grow: 1;
-  flex-shrink: 1;
+  flex-flow: row wrap;
+  flex: 1 1;
   align-items: center;
 `;
 
 const DateContainer = styled.View`
-  flex: 1;
   align-items: flex-end;
   justify-content: center;
   align-self: flex-start;
   margin-top: 2;
-  flex-grow: 0;
-  flex-shrink: 0;
-  flex-basis: 39;
+  flex: 0 0 39px;
   width: 39;
 `;
 

--- a/src/components/issue-event-list-item.component.js
+++ b/src/components/issue-event-list-item.component.js
@@ -15,7 +15,7 @@ const Header = styled.View`
 `;
 
 const IconStyled = styled(Icon)`
-  background-color: ${colors.greyLight}
+  background-color: ${colors.greyLight};
   border-radius: 13;
   width: 26;
   height: 26;
@@ -30,7 +30,7 @@ const ContentContainer = styled.View`
   flex-direction: row;
   flex-grow: 1;
   flex-shrink: 1;
-  border-bottom-color: ${colors.greyLight}
+  border-bottom-color: ${colors.greyLight};
   border-bottom-width: 1;
 `;
 
@@ -56,9 +56,9 @@ const DateContainer = styled.View`
 `;
 
 const BoldText = styled.Text`
-  font-family: ${styledFonts.fontPrimaryBold}
-  font-size: ${normalize(13)}
-  color: ${colors.primaryDark}
+  font-family: ${styledFonts.fontPrimaryBold};
+  font-size: ${normalize(13)};
+  color: ${colors.primaryDark};
 `;
 
 const DateText = styled.Text`

--- a/src/components/mention-area.component.js
+++ b/src/components/mention-area.component.js
@@ -11,18 +11,12 @@ const StyledAnimatedView = styled(Animated.View)`
 
 const SuggestionsRowContainer = styled.View`
   flex-direction: row;
-  padding-top: 5;
-  padding-left: 5;
-  padding-right: 15;
-  padding-bottom: 15;
+  padding: 5px 15px;
 `;
 
 const UserDetailsBox = styled.View`
   flex: 1;
-  margin-left: 5;
-  margin-right: 5;
-  margin-top: 5;
-  margin-bottom: 5;
+  margin: 5px;
 `;
 
 const DisplayNameText = styled.Text`


### PR DESCRIPTION
~~WIP.~~

Modified by stylelint's suggestions. Including:

- add missing commas
- fix unexpected token
- fix unsupported properties, like `padding-horizonal`
- fix unitless shorthands properties
- replace multi properties by shorthands

The last thing is that, is there a better way for empty tagged template? `stylelint` will throw a warning. Of course, maybe we can add a rule to ignore it.

```
const StyledListItem = styled(ListItem).attrs({
  ...
  hideChevron: props => props.unknown,
})``;
```