### PR TITLE
fix(styled-components): Fix react-native-elements related problems

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "react-native-config": "^0.6.0",
     "react-native-cookies": "^3.2.0",
     "react-native-device-info": "^0.11.0",
-    "react-native-elements": "^0.18.1",
+    "react-native-elements": "^0.18.2",
     "react-native-htmlview": "^0.12.0",
     "react-native-i18n": "^2.0.4",
     "react-native-linear-gradient": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "react-native-config": "^0.6.0",
     "react-native-cookies": "^3.2.0",
     "react-native-device-info": "^0.11.0",
-    "react-native-elements": "^0.17.0",
+    "react-native-elements": "^0.18.1",
     "react-native-htmlview": "^0.12.0",
     "react-native-i18n": "^2.0.4",
     "react-native-linear-gradient": "^2.3.0",

--- a/src/components/entity-info.component.js
+++ b/src/components/entity-info.component.js
@@ -23,8 +23,8 @@ const StyledListItem = styled(ListItem).attrs({
     color: colors.greyDark,
     ...fonts.fontPrimary,
   },
-  underlayColor: props => (props.unknown ? null : colors.greyLight),
-  hideChevron: props => props.unknown,
+  underlayColor: props => (props.hideChevron ? null : colors.greyLight),
+  hideChevron: props => props.hideChevron,
 })``;
 
 const getBlogLink = url =>
@@ -78,7 +78,7 @@ export const EntityInfo = ({ entity, orgs, locale, navigation }: Props) => {
             }}
             subtitle={entity.company}
             onPress={() => navigateToCompany(entity.company, orgs, navigation)}
-            unknown={companyInOrgs(entity.company, orgs)}
+            hideChevron={!companyInOrgs(entity.company, orgs)}
           />
         )}
 

--- a/src/components/entity-info.component.js
+++ b/src/components/entity-info.component.js
@@ -15,6 +15,10 @@ type Props = {
 };
 
 const StyledListItem = styled(ListItem).attrs({
+  containerStyle: {
+    borderBottomColor: colors.greyLight,
+    borderBottomWidth: 1,
+  },
   titleStyle: {
     color: colors.black,
     ...fonts.fontPrimary,

--- a/src/components/issue-description.component.js
+++ b/src/components/issue-description.component.js
@@ -106,7 +106,7 @@ export class IssueDescription extends Component {
 
   renderLabelButtons = labels => {
     return labels
-      .slice(0, 5)
+      .slice(0, 3)
       .map(label => <InlineLabel key={label.id} label={label} />);
   };
 

--- a/src/components/issue-description.component.js
+++ b/src/components/issue-description.component.js
@@ -44,6 +44,10 @@ const RepoLink = styled(ListItem).attrs({
   leftIconContainerStyle: {
     flex: 0,
   },
+  containerStyle: {
+    borderBottomColor: colors.greyLight,
+    borderBottomWidth: 1,
+  },
 })``;
 
 const IssueTitle = styled(ListItem).attrs({

--- a/src/components/issue-description.component.js
+++ b/src/components/issue-description.component.js
@@ -8,7 +8,7 @@ import styled from 'styled-components/native';
 import {
   StateBadge,
   MembersList,
-  LabelButton,
+  InlineLabel,
   DiffBlocks,
   Button,
 } from 'components';
@@ -102,8 +102,8 @@ export class IssueDescription extends Component {
 
   renderLabelButtons = labels => {
     return labels
-      .slice(0, 3)
-      .map(label => <LabelButton key={label.id} label={label} />);
+      .slice(0, 5)
+      .map(label => <InlineLabel key={label.id} label={label} />);
   };
 
   render() {

--- a/src/components/issue-description.component.js
+++ b/src/components/issue-description.component.js
@@ -13,7 +13,7 @@ import {
   Button,
 } from 'components';
 import { translate } from 'utils';
-import { colors, styledFonts, normalize } from 'config';
+import { colors, fonts, normalize } from 'config';
 import { v3 } from 'api';
 
 const styles = StyleSheet.create({
@@ -35,19 +35,28 @@ const ContainerBorderBottom = styled.View`
   border-bottom-color: ${colors.greyLight};
 `;
 
-const ListItemStyled = styled(ListItem)`
-  color: ${colors.primaryDark};
-  font-family: ${styledFonts.fontPrimarySemiBold};
-`;
+const RepoLink = styled(ListItem).attrs({
+  titleStyle: {
+    color: colors.primaryDark,
+    ...fonts.fontPrimarySemiBold,
+    fontSize: normalize(10),
+  },
+  leftIconContainerStyle: {
+    flex: 0,
+  },
+})``;
 
-const ListItemURL = ListItemStyled.extend`
-  font-size: ${normalize(10)};
-`;
-
-const ListItemIssueTitle = ListItemStyled.extend`
-  border-bottom-width: 0;
-  flex: 1;
-`;
+const IssueTitle = styled(ListItem).attrs({
+  titleStyle: {
+    color: colors.primaryDark,
+    ...fonts.fontPrimarySemiBold,
+  },
+  containerStyle: {
+    borderBottomWidth: 0,
+    flex: 1,
+  },
+  titleNumberOfLines: 0,
+})``;
 
 const DiffBlocksContainer = styled.View`
   flex-direction: row;
@@ -124,7 +133,7 @@ export class IssueDescription extends Component {
     return (
       <ContainerBorderBottom>
         {issue.repository_url && (
-          <ListItemURL
+          <RepoLink
             title={issue.repository_url.replace(`${v3.root}/repos/`, '')}
             leftIcon={{
               name: 'repo',
@@ -138,7 +147,7 @@ export class IssueDescription extends Component {
         )}
 
         <HeaderContainer>
-          <ListItemIssueTitle
+          <IssueTitle
             title={issue.title}
             subtitle={moment(issue.created_at).fromNow()}
             leftIcon={{

--- a/src/components/issue-event-list-item.component.js
+++ b/src/components/issue-event-list-item.component.js
@@ -1,28 +1,53 @@
 import React, { Component } from 'react';
 import { Text } from 'react-native';
-import { Icon } from 'react-native-elements';
+import { Icon as BaseIcon } from 'react-native-elements';
 import moment from 'moment/min/moment-with-locales.min';
 import { colors, styledFonts, normalize } from 'config';
 import { InlineLabel } from 'components';
 import styled from 'styled-components/native';
 
-const Header = styled.View`
-  padding-right: 10;
+const marginLeftForIconName = name => {
+  switch (name) {
+    case 'git-branch':
+    case 'git-merge':
+    case 'primitive-dot':
+      return 8;
+    case 'bookmark':
+      return 6;
+    case 'person':
+    case 'lock':
+      return 4;
+    default:
+      return 2;
+  }
+};
+
+const Container = styled.View`
   padding-top: 10;
+  padding-right: 10;
   background-color: transparent;
   flex-direction: row;
   align-items: stretch;
 `;
 
-const IconStyled = styled(Icon)`
-  background-color: ${colors.greyLight};
-  border-radius: 13;
-  width: 26;
-  height: 26;
-  margin-left: 14;
-  margin-right: 14;
-  flex: 0 0 26px;
-`;
+const Icon = styled(BaseIcon).attrs({
+  iconStyle: props => ({
+    marginTop: 1,
+    color: props.color,
+    marginLeft: marginLeftForIconName(props.name),
+  }),
+  containerStyle: props => ({
+    borderRadius: 13,
+    width: 26,
+    height: 26,
+    marginLeft: 14,
+    marginRight: 14,
+    flexGrow: 0,
+    flexShrink: 0,
+    flexBasis: 26,
+    backgroundColor: props.backgroundColor,
+  }),
+})``;
 
 const ContentContainer = styled.View`
   flex-direction: row;
@@ -47,14 +72,14 @@ const DateContainer = styled.View`
   width: 39;
 `;
 
+const Date = styled.Text`
+  color: ${colors.greyDark};
+`;
+
 const BoldText = styled.Text`
   font-family: ${styledFonts.fontPrimaryBold};
   font-size: ${normalize(13)};
   color: ${colors.primaryDark};
-`;
-
-const DateText = styled.Text`
-  color: ${colors.greyDark};
 `;
 
 export class IssueEventListItem extends Component {
@@ -300,22 +325,6 @@ export class IssueEventListItem extends Component {
   }
 }
 
-const marginLeftForIconName = name => {
-  switch (name) {
-    case 'git-branch':
-    case 'git-merge':
-    case 'primitive-dot':
-      return 8;
-    case 'bookmark':
-      return 6;
-    case 'person':
-    case 'lock':
-      return 4;
-    default:
-      return 2;
-  }
-};
-
 class Event extends Component {
   props: {
     iconName: String,
@@ -335,25 +344,21 @@ class Event extends Component {
     } = this.props;
 
     return (
-      <Header>
-        <IconStyled
-          iconStyle={{
-            marginLeft: marginLeftForIconName(iconName),
-            marginTop: 1,
-            color: iconColor,
-          }}
-          containerStyle={[{ backgroundColor: iconBackgroundColor }]}
+      <Container>
+        <Icon
           name={iconName}
           type="octicon"
           size={16}
+          color={iconColor}
+          backgroundColor={iconBackgroundColor}
         />
         <ContentContainer>
           <EventTextContainer>{text}</EventTextContainer>
           <DateContainer>
-            <DateText>{moment(createdAt).fromNow()}</DateText>
+            <Date>{moment(createdAt).fromNow()}</Date>
           </DateContainer>
         </ContentContainer>
-      </Header>
+      </Container>
     );
   }
 }

--- a/src/components/repository-list-item.component.js
+++ b/src/components/repository-list-item.component.js
@@ -49,6 +49,10 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     flex: 1,
   },
+  container: {
+    borderBottomColor: colors.greyLight,
+    borderBottomWidth: 1,
+  },
 });
 
 const renderTitle = (repository, showFullName) => (
@@ -128,6 +132,7 @@ export const RepositoryListItem = ({
       color: colors.grey,
       type: 'octicon',
     }}
+    containerStyle={styles.container}
     underlayColor={colors.greyLight}
     onPress={() => navigation.navigate('Repository', { repository })}
   />

--- a/src/repository/screens/repository-code-list.screen.js
+++ b/src/repository/screens/repository-code-list.screen.js
@@ -40,6 +40,10 @@ const styles = StyleSheet.create({
     fontSize: normalize(18),
     textAlign: 'center',
   },
+  container: {
+    borderBottomColor: colors.greyLight,
+    borderBottomWidth: 1,
+  },
 });
 
 class RepositoryCodeList extends Component {
@@ -99,6 +103,7 @@ class RepositoryCodeList extends Component {
         type: 'octicon',
       }}
       titleStyle={item.type === 'dir' ? styles.titleBold : styles.title}
+      containerStyle={styles.container}
       onPress={() => this.goToPath(item)}
       underlayColor={colors.greyLight}
     />

--- a/src/repository/screens/repository.screen.js
+++ b/src/repository/screens/repository.screen.js
@@ -65,6 +65,10 @@ const styles = StyleSheet.create({
     color: colors.black,
     ...fonts.fontPrimary,
   },
+  listContainerStyle: {
+    borderBottomColor: colors.greyLight,
+    borderBottomWidth: 1,
+  },
 });
 
 class Repository extends Component {
@@ -280,32 +284,35 @@ class Repository extends Component {
         >
           {initalRepository &&
             !initalRepository.owner &&
-            isPendingRepository &&
-            <SectionList
-              title={translate('repository.main.ownerTitle', locale)}
-            >
-              <LoadingUserListItem />
-            </SectionList>}
+            isPendingRepository && (
+              <SectionList
+                title={translate('repository.main.ownerTitle', locale)}
+              >
+                <LoadingUserListItem />
+              </SectionList>
+            )}
 
           {!(initalRepository && initalRepository.owner) &&
             (repository && repository.owner) &&
-            !isPendingRepository &&
-            <SectionList
-              title={translate('repository.main.ownerTitle', locale)}
-            >
-              <UserListItem user={repository.owner} navigation={navigation} />
-            </SectionList>}
+            !isPendingRepository && (
+              <SectionList
+                title={translate('repository.main.ownerTitle', locale)}
+              >
+                <UserListItem user={repository.owner} navigation={navigation} />
+              </SectionList>
+            )}
 
           {initalRepository &&
-            initalRepository.owner &&
-            <SectionList
-              title={translate('repository.main.ownerTitle', locale)}
-            >
-              <UserListItem
-                user={initalRepository.owner}
-                navigation={navigation}
-              />
-            </SectionList>}
+            initalRepository.owner && (
+              <SectionList
+                title={translate('repository.main.ownerTitle', locale)}
+              >
+                <UserListItem
+                  user={initalRepository.owner}
+                  navigation={navigation}
+                />
+              </SectionList>
+            )}
 
           {(isPendingRepository || isPendingContributors) && (
             <LoadingMembersList
@@ -313,7 +320,7 @@ class Repository extends Component {
             />
           )}
 
-          {!isPendingContributors &&
+          {!isPendingContributors && (
             <MembersList
               title={translate('repository.main.contributorsTitle', locale)}
               members={contributors}
@@ -322,10 +329,11 @@ class Repository extends Component {
                 locale
               )}
               navigation={navigation}
-            />}
+            />
+          )}
 
           <SectionList title={translate('repository.main.sourceTitle', locale)}>
-            {showReadMe &&
+            {showReadMe && (
               <ListItem
                 title={translate('repository.main.readMe', locale)}
                 leftIcon={{
@@ -334,15 +342,18 @@ class Repository extends Component {
                   type: 'octicon',
                 }}
                 titleStyle={styles.listTitle}
+                containerStyle={styles.listContainerStyle}
                 onPress={() =>
                   navigation.navigate('ReadMe', {
                     repository,
                   })}
                 underlayColor={colors.greyLight}
-              />}
+              />
+            )}
             <ListItem
               title={translate('repository.main.viewSource', locale)}
               titleStyle={styles.listTitle}
+              containerStyle={styles.listContainerStyle}
               leftIcon={{
                 name: 'code',
                 color: colors.grey,
@@ -358,47 +369,48 @@ class Repository extends Component {
           </SectionList>
 
           {!repository.fork &&
-            repository.has_issues &&
-            <SectionList
-              loading={isPendingIssues}
-              title={translate('repository.main.issuesTitle', locale)}
-              noItems={openIssues.length === 0}
-              noItemsMessage={
-                pureIssues.length === 0
-                  ? translate('repository.main.noIssuesMessage', locale)
-                  : translate('repository.main.noOpenIssuesMessage', locale)
-              }
-              showButton
-              buttonTitle={
-                pureIssues.length > 0
-                  ? translate('repository.main.viewAllButton', locale)
-                  : translate('repository.main.newIssueButton', locale)
-              }
-              buttonAction={() => {
-                if (pureIssues.length > 0) {
-                  navigation.navigate('IssueList', {
-                    title: translate('repository.issueList.title', locale),
-                    type: 'issue',
-                    issues: pureIssues,
-                  });
-                } else {
-                  navigation.navigate('NewIssue', {
-                    title: translate('issue.newIssue.title', locale),
-                  });
+            repository.has_issues && (
+              <SectionList
+                loading={isPendingIssues}
+                title={translate('repository.main.issuesTitle', locale)}
+                noItems={openIssues.length === 0}
+                noItemsMessage={
+                  pureIssues.length === 0
+                    ? translate('repository.main.noIssuesMessage', locale)
+                    : translate('repository.main.noOpenIssuesMessage', locale)
                 }
-              }}
-            >
-              {openIssues
-                .slice(0, 3)
-                .map(item =>
-                  <IssueListItem
-                    key={item.id}
-                    type="issue"
-                    issue={item}
-                    navigation={navigation}
-                  />
-                )}
-            </SectionList>}
+                showButton
+                buttonTitle={
+                  pureIssues.length > 0
+                    ? translate('repository.main.viewAllButton', locale)
+                    : translate('repository.main.newIssueButton', locale)
+                }
+                buttonAction={() => {
+                  if (pureIssues.length > 0) {
+                    navigation.navigate('IssueList', {
+                      title: translate('repository.issueList.title', locale),
+                      type: 'issue',
+                      issues: pureIssues,
+                    });
+                  } else {
+                    navigation.navigate('NewIssue', {
+                      title: translate('issue.newIssue.title', locale),
+                    });
+                  }
+                }}
+              >
+                {openIssues
+                  .slice(0, 3)
+                  .map(item => (
+                    <IssueListItem
+                      key={item.id}
+                      type="issue"
+                      issue={item}
+                      navigation={navigation}
+                    />
+                  ))}
+              </SectionList>
+            )}
 
           <SectionList
             loading={isPendingIssues}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5629,9 +5629,9 @@ react-native-drawer-layout@1.3.2:
   dependencies:
     react-native-dismiss-keyboard "1.0.0"
 
-react-native-elements@^0.18.1:
-  version "0.18.1"
-  resolved "https://registry.yarnpkg.com/react-native-elements/-/react-native-elements-0.18.1.tgz#6914b2d7cd4f28fc41cb8eb45453ae284ba4a0a0"
+react-native-elements@^0.18.2:
+  version "0.18.2"
+  resolved "https://registry.yarnpkg.com/react-native-elements/-/react-native-elements-0.18.2.tgz#f3e814db3983d3c52c31a40293220439745e5ab4"
   dependencies:
     lodash.isempty "^4.4.0"
     lodash.times "^4.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3333,10 +3333,6 @@ image-size@^0.6.0:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.6.1.tgz#98122a562d59dcc097ef1b2c8191866eb8f5d663"
 
-immutable@^3.8.1:
-  version "3.8.1"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.1.tgz#200807f11ab0f72710ea485542de088075f68cd2"
-
 import-from@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/import-from/-/import-from-2.1.0.tgz#335db7f2a7affd53aaa471d4b8021dee36b7f3b1"
@@ -5633,16 +5629,14 @@ react-native-drawer-layout@1.3.2:
   dependencies:
     react-native-dismiss-keyboard "1.0.0"
 
-react-native-elements@^0.17.0:
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/react-native-elements/-/react-native-elements-0.17.0.tgz#b5f3e0959b41f04f0aa6a1c1a547be22f94c8a12"
+react-native-elements@^0.18.1:
+  version "0.18.1"
+  resolved "https://registry.yarnpkg.com/react-native-elements/-/react-native-elements-0.18.1.tgz#6914b2d7cd4f28fc41cb8eb45453ae284ba4a0a0"
   dependencies:
     lodash.isempty "^4.4.0"
     lodash.times "^4.3.2"
     opencollective "^1.0.3"
     prop-types "^15.5.8"
-    react-native-side-menu "^1.0.2"
-    react-native-tab-navigator "^0.3.4"
 
 react-native-htmlview@^0.12.0:
   version "0.12.0"
@@ -5704,12 +5698,6 @@ react-native-safari-view@^2.0.0:
     create-react-class "^15.6.2"
     prop-types "^15.6.0"
 
-react-native-side-menu@^1.0.2:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/react-native-side-menu/-/react-native-side-menu-1.1.3.tgz#6ef5d2232ecf718312df6cedef019148bac3073a"
-  dependencies:
-    prop-types "^15.5.10"
-
 react-native-swiper@^1.5.13:
   version "1.5.13"
   resolved "https://registry.yarnpkg.com/react-native-swiper/-/react-native-swiper-1.5.13.tgz#fa695cd4ab77b9a9df2d2bfee38ea7274dd07a2e"
@@ -5728,13 +5716,6 @@ react-native-syntax-highlighter@^1.2.1:
     babel-preset-react "^6.24.1"
     babel-runtime "^6.23.0"
     react-syntax-highlighter "^5.6.2"
-
-react-native-tab-navigator@^0.3.4:
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/react-native-tab-navigator/-/react-native-tab-navigator-0.3.4.tgz#54a18f1ad06a09d4a0de81ff00416bc1b760c960"
-  dependencies:
-    immutable "^3.8.1"
-    prop-types "^15.5.10"
 
 react-native-tab-view@^0.0.67:
   version "0.0.67"


### PR DESCRIPTION
Spent the afternoon fixing up the problems introduced by the styled-components migration:

- Upgrade to react-native-elements 0.18.1 which contains a fix for styled components supports
- Fixed problems:
  1. `<EntityInfo/>`: The test on the company was inverted. Also renamed the prop.
  2. `<IssueDescription/>`: Fix the repo link header, the issue title & use InlineLabel instead of LabelButton for issues/pulls label
  3. `<IssueEventListItem/>`: Fix icon styling
  4. `<*List />` : Adjusted the border bottom color, as the default changed in RNE from 0.7 to 0.17 and this is why we had bolder lines.

This should fix #615 #580 and several comments in #569