### PR TITLE
feat(markdown): Add coverall badge support

### DIFF
--- a/src/components/coverall-badge.component.js
+++ b/src/components/coverall-badge.component.js
@@ -46,12 +46,14 @@ const ValueContainer = styled(LinearGradient).attrs({
   padding-top: 1;
   align-items: center;
 `;
+
 const ValueBorderContainer = ValueContainer.extend`
   width: 20;
   border-radius: 3;
   position: absolute;
   left: 83;
 `;
+
 const Value = Label.extend`
   font-size: ${props => normalize(props.value === 100 ? 10 : 11)};
 `;

--- a/src/components/coverall-badge.component.js
+++ b/src/components/coverall-badge.component.js
@@ -63,7 +63,7 @@ export const CoverallBadge = ({ coverage = 100 }: Props) => (
     </LabelContainer>
     <ValueBorderContainer />
     <ValueContainer>
-      <Value value={coverage}>{coverage}%</Value>
+      <Value value={coverage}>{coverage === -1 ? 'ERR' : `${coverage}%`}</Value>
     </ValueContainer>
   </Container>
 );

--- a/src/components/coverall-badge.component.js
+++ b/src/components/coverall-badge.component.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import LinearGradient from 'react-native-linear-gradient';
+import styled from 'styled-components/native';
+
+import { fonts, normalize } from 'config';
+
+type Props = {
+  coverage: number,
+};
+
+const Container = styled.View`
+  flex-direction: row;
+  border-radius: 3;
+  width: 102;
+  background-color: #5e5e5e;
+`;
+
+const LabelContainer = styled(LinearGradient).attrs({
+  colors: ['#5e5e5e', '#4d4d4d'],
+})`
+  width: 63;
+  height: 20;
+  align-items: center;
+  border-radius: 3;
+`;
+
+const Label = styled.Text`
+  ${{ ...fonts.fontPrimaryBold }};
+  font-weight: bold;
+  background-color: transparent;
+  color: #ffffff;
+  text-shadow-color: #00000099;
+  padding-left: 3;
+  padding-top: 1;
+  text-shadow-offset: {
+    height: 1;
+  }
+  font-size: ${normalize(11)};
+`;
+
+const ValueContainer = styled(LinearGradient).attrs({
+  colors: ['#e05d44', '#BB5C46'],
+})`
+  width: 36;
+  height: 20;
+  padding-top: 1;
+  align-items: center;
+`;
+const ValueBorderContainer = ValueContainer.extend`
+  width: 20;
+  border-radius: 3;
+  position: absolute;
+  left: 83;
+`;
+const Value = Label.extend`
+  font-size: ${props => normalize(props.value === 100 ? 10 : 11)};
+`;
+
+export const CoverallBadge = ({ coverage = 100 }: Props) => (
+  <Container>
+    <LabelContainer>
+      <Label>coverage</Label>
+    </LabelContainer>
+    <ValueBorderContainer />
+    <ValueContainer>
+      <Value value={coverage}>{coverage}%</Value>
+    </ValueContainer>
+  </Container>
+);

--- a/src/components/github-htmlview.component.js
+++ b/src/components/github-htmlview.component.js
@@ -6,7 +6,7 @@ import SyntaxHighlighter from 'react-native-syntax-highlighter';
 import { github as GithubStyle } from 'react-syntax-highlighter/dist/styles';
 import entities from 'entities';
 
-import { ImageZoom, ToggleView } from 'components';
+import { ImageZoom, ToggleView, CoverallBadge } from 'components';
 import { colors, fonts, normalize } from 'config';
 
 const textStyle = Platform.select({
@@ -302,6 +302,31 @@ export class GithubHtmlView extends Component {
                 {'\n'}
               </Text>
             );
+          }
+
+          if (
+            node.attribs['data-canonical-src'] &&
+            node.attribs['data-canonical-src'].startsWith(
+              'https://coveralls.io/builds'
+            )
+          ) {
+            let value;
+
+            try {
+              const coverageReport = node.next.next.children[0].data;
+              const percentage = coverageReport.match(
+                /Coverage .* (to|at) (\d{1,3}).?(\d{1})?/
+              );
+
+              value = parseInt(percentage[2], 10);
+              if (parseInt(percentage[3], 10) >= 5) {
+                value += 1;
+              }
+            } catch (exception) {
+              value = -1;
+            }
+
+            return <CoverallBadge coverage={value} />;
           }
 
           const zoom = hasAncestor(node, ['table']) ? 0.3 : 0.6;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -3,6 +3,7 @@ export * from './loading-indicators';
 export * from './code-line.component';
 export * from './comment-input.component';
 export * from './comment-list-item.component';
+export * from './coverall-badge.component';
 export * from './diff-blocks.component';
 export * from './entity-info.component';
 export * from './issue-description.component';


### PR DESCRIPTION
Implements #584 

I tried to add support for SVG in `GithubHtmlView` but it ended up like this using `react-native-svg`, which seems to be the most popular lib up to now:
![screen shot 2017-11-05 at 1 10 58 am](https://user-images.githubusercontent.com/304450/32411384-713befc0-c1d9-11e7-88fa-b95850368ee9.png)

I ended up recreating the badge using styled-components, and it looks quiet realistic thanks to `<LinearGradient />`:
![screen shot 2017-11-05 at 3 30 13 am](https://user-images.githubusercontent.com/304450/32411393-b1f0191a-c1d9-11e7-998a-7445c09d684f.png)
<sub>(*OCD: it's still 6px wider than the original, cause I had to do some weird stuff to get the rounded borders on only one side*)</sub>

The only problem I'm left with is accurately coloring the right side of the badge.

Fact is, the only information I have is the sentence written below the badge, and this give no hints whether coverage is considered good enough (green) or not (red), in regards of the project-configured threshold.

The only way I see for now, would be to fetch the SVG and decode its content to grab the color from there, but while we're there, we might as well grab the percentage from there (and remove the parsing from GithubHtmlView).

I'm curious for your opinions on this one :)

And of course, we could settle on a neutral lighter gray for now and worry about this in another PR 👯‍♂️ 

<!-- DO NOT MODIFY BELOW THIS LINE -->
<!-- ----------------------------- -->
<!-- GITPOINT_PR -->
