### PR TITLE
fix(search-bar): Compile Ionicons for Android

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -76,6 +76,7 @@ import com.android.build.OutputFile
     // Name of the font files you want to copy
     iconFontNames: [
       'FontAwesome.ttf',
+      'Ionicons.ttf',
       'MaterialIcons.ttf',
       'Octicons.ttf']
   ]
@@ -144,6 +145,7 @@ android {
 }
 
 dependencies {
+    compile project(':react-native-vector-icons')
     compile project(':react-native-linear-gradient')
     compile project(':react-native-cookies')
     compile project(':react-native-i18n')
@@ -151,7 +153,6 @@ dependencies {
     compile project(':react-native-config')
     compile project(':react-native-code-push')
     compile project(':react-native-device-info')
-    compile project(':react-native-vector-icons')
     compile fileTree(dir: "libs", include: ["*.jar"])
     compile "com.android.support:appcompat-v7:23.0.1"
     compile "com.facebook.react:react-native:+"  // From node_modules


### PR DESCRIPTION
| Question         | Response    |
| ---------------- | ----------- |
| Version?         | master      |
| Devices tested?  | Android Nexus 5X (simulator) |
| Bug fix?         | yes     |
| New feature?     | no      |
| Includes tests?  | no      |
| All Tests pass?  | yes      |
| Related ticket?  | #630        |

---

## Screenshots

<!--
  Replace the images in the table below with screenshots of your changes before
  and after. If this is not applicable (i.e. absolutely NO visual changes), feel
  free to delete this section.
-->

| Before   | After    |
| -------- | -------- |
| ![screen shot 2017-11-06 at 9 40 08 am](https://user-images.githubusercontent.com/304450/32433457-4d63c61a-c2db-11e7-9c43-19afaef3cb27.png) | ![screen shot 2017-11-06 at 10 14 16 am](https://user-images.githubusercontent.com/304450/32433464-5510d222-c2db-11e7-90d0-790fb17a21d8.png) | 

## Description

Added Ionicons.ttf compilation back in `build.gradle` as it is needed by `react-native-material-design-searchbar`.

/cc @dyesseyumba for info
/cc @chinesedfan I'm wondering how this was still working fine for iOS. Did we really remove unwanted TTF there? 🤔

Fix #630

<!-- DO NOT MODIFY BELOW THIS LINE -->
<!-- ----------------------------- -->
<!-- GITPOINT_PR -->
