### PR TITLE
chore: Make travis run eslint first and fail immediately if needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,4 @@ cache:
 node_js:
   - 7
 script:
-  - yarn run test:coverage
-  - yarn run eslint
+  - yarn run eslint && yarn run test:coverage


### PR DESCRIPTION
Should fix #632.

Due to https://github.com/travis-ci/travis-ci/issues/1066, the solution is not as simple as inverting the two lines.
Instead, I made the script a one liner that runs eslint before coverage.

This is not tested as I don't want to create a fake & bogus PR :/

<!-- DO NOT MODIFY BELOW THIS LINE -->
<!-- ----------------------------- -->
<!-- GITPOINT_PR -->
