### PR TITLE
fix: re-enable color prop for the badge component

### DIFF
--- a/src/components/badge.component.js
+++ b/src/components/badge.component.js
@@ -19,15 +19,14 @@ const BadgeContainer = styled.View`
   height: 18;
   border-color: ${colors.alabaster};
   border-width: 1;
-  ${({ backgroundColor }) => `background-color: ${backgroundColor};`};
+  background-color: ${({ backgroundColor }) => backgroundColor};
 `;
 
 const BadgeText = styled.Text`
   ${{ ...fonts.fontPrimaryBold }};
   background-color: transparent;
-  ${({ color }) => `color: ${color || colors.black};`};
-  ${({ largeText }) =>
-    `font-size: ${largeText ? normalize(9.5) : normalize(7)};`};
+  color: ${({ color }) => color || color.black};
+  font-size: ${({ largeText }) => (largeText ? normalize(9.5) : normalize(7))};
 `;
 
 export const Badge = ({ color, backgroundColor, text, largeText }: Props) => (

--- a/src/components/badge.component.js
+++ b/src/components/badge.component.js
@@ -25,7 +25,7 @@ const BadgeContainer = styled.View`
 const BadgeText = styled.Text`
   ${{ ...fonts.fontPrimaryBold }};
   background-color: transparent;
-  ${({ color }) => `color: ${color};`};
+  ${({ color }) => `color: ${color || colors.black};`};
   ${({ largeText }) =>
     `font-size: ${largeText ? normalize(9.5) : normalize(7)};`};
 `;

--- a/src/components/badge.component.js
+++ b/src/components/badge.component.js
@@ -25,6 +25,7 @@ const BadgeContainer = styled.View`
 const BadgeText = styled.Text`
   ${{ ...fonts.fontPrimaryBold }};
   background-color: transparent;
+  ${({ color }) => `color: ${color};`};
   ${({ largeText }) =>
     `font-size: ${largeText ? normalize(9.5) : normalize(7)};`};
 `;


### PR DESCRIPTION
| Question         | Response    |
| ---------------- | ----------- |
| Version?         | master      |
| Devices tested?  | iPhone 7, Android Nexus 5 |
| Bug fix?         | yes     |
| New feature?     | no      |
| Includes tests?  | no      |
| All Tests pass?  | yes     |
| Related ticket?  | #581        |

---

## Screenshots

<!--
  Replace the images in the table below with screenshots of your changes before
  and after. If this is not applicable (i.e. absolutely NO visual changes), feel
  free to delete this section.
-->

| Before   | After    |
| -------- | -------- |
| <img width="349" alt="screen shot 2017-11-25 at 2 41 37 pm" src="https://user-images.githubusercontent.com/304450/33231134-6c33bb08-d1f0-11e7-939b-b3036f974dbd.png"><img width="343" alt="screen shot 2017-11-25 at 2 46 08 pm" src="https://user-images.githubusercontent.com/304450/33231135-6c4eeebe-d1f0-11e7-8fd2-ee4d5adb805c.png"> | <img width="350" alt="screen shot 2017-11-25 at 2 48 19 pm" src="https://user-images.githubusercontent.com/304450/33231137-6c830f64-d1f0-11e7-9a79-88c322ab0369.png"> <img width="339" alt="screen shot 2017-11-25 at 2 48 12 pm" src="https://user-images.githubusercontent.com/304450/33231136-6c67caf6-d1f0-11e7-9529-66e53c0efafc.png">  |

## Description

#535 seems to have lost the `color` prop for the badge text, making it always black (the default).
This fixed the style be reading from that prop again when it's available.


<!-- DO NOT MODIFY BELOW THIS LINE -->
<!-- ----------------------------- -->
<!-- GITPOINT_PR -->
