### PR TITLE
fix: setTranslucent and setBackgroundColor are Android only

### DIFF
--- a/App.js
+++ b/App.js
@@ -6,6 +6,7 @@ import {
   AsyncStorage,
   LayoutAnimation,
   StatusBar,
+  Platform,
 } from 'react-native';
 import { persistStore } from 'redux-persist';
 import createEncryptor from 'redux-persist-transform-encrypt';
@@ -103,8 +104,10 @@ class App extends Component {
       routeName
     );
 
-    StatusBar.setTranslucent(translucent);
-    StatusBar.setBackgroundColor(backgroundColor);
+    if (Platform.OS === 'android') {
+      StatusBar.setTranslucent(translucent);
+      StatusBar.setBackgroundColor(backgroundColor);
+    }
     StatusBar.setBarStyle(barStyle);
   }
 


### PR DESCRIPTION
| Question         | Response    |
| ---------------- | ----------- |
| Version?         | master      |
| Devices tested?  | iPhone 7 |
| Bug fix?         | yes      |
| New feature?     | no      |
| Includes tests?  | no      |
| All Tests pass?  | yes      |

---

## Description

This PR silences the following warning on iOS by testing the platform OS:
```
2017-12-04 14:05:11.418 [warn][tid:com.facebook.react.JavaScript] `setTranslucent` is only available on Android
2017-12-04 14:05:11.418 [warn][tid:com.facebook.react.JavaScript] `setBackgroundColor` is only available on Android
```


<!-- DO NOT MODIFY BELOW THIS LINE -->
<!-- ----------------------------- -->
<!-- GITPOINT_PR -->
