### PR TITLE
fix: remove containers styles that confuses the button

### DIFF
--- a/src/components/issue-description.component.js
+++ b/src/components/issue-description.component.js
@@ -82,8 +82,6 @@ const AssigneesSection = styled.View`
 `;
 
 const MergeButtonContainer = styled.View`
-  flex: 1;
-  flex-direction: row;
   justify-content: center;
   align-items: center;
   padding-top: 15;


### PR DESCRIPTION
| Question .           | Response    |
| ---------------- | ------------ |
| Version?             | master .        |
| Devices tested? | iPhone 7, Nexus 5 |
| Bug fix?              | yes               |
| New feature?     | no                 |
| Includes tests?  | no                 |
| All Tests pass?  | yes               |
| Related ticket?  | #624            |

---

## Screenshots

| Before   | After    |
| -------- | -------- |
| <img width="348" alt="screen shot 2017-12-09 at 11 27 57 am" src="https://user-images.githubusercontent.com/304450/33794838-1c560c64-dcd4-11e7-8f73-09e5615f64e3.png"> | <img width="347" alt="screen shot 2017-12-09 at 11 26 35 am" src="https://user-images.githubusercontent.com/304450/33794839-210e8fec-dcd4-11e7-8ad9-bc24dc0abfed.png"> |

## Description

Removed two (unneeded) styles from the container, that seems to be confusing the button layout.
Wasn't able to reproduce the problem anymore with this patch applied.

This is the iOS fix for #624, tested on both iOS and Android (no regressions)

<!-- DO NOT MODIFY BELOW THIS LINE -->
<!-- ----------------------------- -->
<!-- GITPOINT_PR -->
