### PR TITLE
fix(android): fix Button layout

### DIFF
--- a/src/components/button.component.js
+++ b/src/components/button.component.js
@@ -79,8 +79,6 @@ const sizes = {
       paddingBottom: 5,
       paddingEnd: 8,
       paddingLeft: 8,
-      marginLeft: 4,
-      marginRight: 4,
     },
     textStyle: {
       fontSize: normalize(12),
@@ -95,8 +93,6 @@ const sizes = {
       paddingBottom: 8,
       paddingRight: 14,
       paddingLeft: 14,
-      marginLeft: 6,
-      marginRight: 6,
     },
     textStyle: {
       fontSize: normalize(14),
@@ -111,8 +107,6 @@ const sizes = {
       paddingBottom: 13,
       paddingRight: 17,
       paddingLeft: 17,
-      marginLeft: 8,
-      marginRight: 8,
     },
     textStyle: {
       fontSize: normalize(16),
@@ -152,6 +146,10 @@ const defaultDisabledTextStyle = {
   color: '#d2d2d2',
 };
 
+const defaultContainerViewStyle = {
+  borderRadius: 2,
+};
+
 export class Button extends Component {
   props: {
     icon: string,
@@ -178,6 +176,7 @@ export class Button extends Component {
         {...this.props}
         title={isAndroid ? title.toUpperCase() : title}
         raised={isAndroid}
+        containerViewStyle={defaultContainerViewStyle}
         buttonStyle={{
           ...defaultButtonStyle,
           ...types[type].buttonStyle,


### PR DESCRIPTION
| Question         | Response    |
| ---------------- | ----------- |
| Version?         | v1.4.0      |
| Devices tested?  | iPhone 7, Nexus 5 |
| Bug fix?         | yes      |
| New feature?     | no      |
| Includes tests?  | no      |
| All Tests pass?  | yes      |
| Related ticket?  | #624         |

---

## Screenshots


| Before   | After    |
| -------- | -------- |
| <img width="315" alt="screen shot 2017-12-09 at 12 02 18 pm" src="https://user-images.githubusercontent.com/304450/33795053-ffd243be-dcd8-11e7-8a16-190d5ac9ce1a.png"> | <img width="314" alt="screen shot 2017-12-09 at 11 59 42 am" src="https://user-images.githubusercontent.com/304450/33795055-0a0872a4-dcd9-11e7-8324-6b10d3879b4f.png"> |

## Description

This PR fixes the second and last problem mentionned in #624. `react-native-elements` introduced a `containerViewStyle` prop that changed the layout. This PR catches up with that changes.

Also removed the margins which shouldn't have been there in the first place.

Tested on both Android and iOS (no regressions).

<!-- DO NOT MODIFY BELOW THIS LINE -->
<!-- ----------------------------- -->
<!-- GITPOINT_PR -->
