### PR TITLE
fix(issue): Fix crash due to undefined navigation params

### DIFF
--- a/src/issue/screens/issue.screen.js
+++ b/src/issue/screens/issue.screen.js
@@ -239,16 +239,16 @@ class Issue extends Component {
 
   handleActionSheetPress = index => {
     if (index === 0) {
-      openURLInView(this.props.navigation.state.params.issue.html_url);
+      openURLInView(this.props.issue.html_url);
     }
   };
 
   postComment = body => {
-    const { repository, navigation } = this.props;
+    const { issue, repository } = this.props;
 
     const repoName = repository.name;
     const owner = repository.owner.login;
-    const issueNum = navigation.state.params.issue.number;
+    const issueNum = issue.number;
 
     this.props.postIssueComment(body, owner, repoName, issueNum);
     Keyboard.dismiss();


### PR DESCRIPTION
<!--
  Bonjour!

  We can't express how grateful we are that you're working on making GitPoint
  better! We're thrilled to take a look at the changes you've made and merge
  them in as soon as possible. Please fill out this template to make the
  reviewal process as quick and smooth as possible. In addition, please make
  sure you remember to add yourself to the contributors list with the following
  command:

  $ yarn contributors:add

  Make sure the title of your PR follows our commit style guidelines (see other
  open PR's for reference if you're confused):

  https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines

  Thanks again for your hard work!
-->

| Question         | Response    |
| ---------------- | ----------- |
| Version?         | v1.4.0      |
| Devices tested?  | iPhone 6, iOS 11.0 simulator |
| Bug fix?         | yes      |
| New feature?     | no      |
| Includes tests?  | no      |
| All Tests pass?  | yes      |
| Related ticket?  | #201        |

---

## Description

<!--
  What changes did you make?
-->

From #332, we can learn that `this.props.navigation.state.params.issue` is not available when visiting from notifications. The safer variable is `this.props.issue`.

By scanning similar codes, I found another crash and fixed. If visiting an issue without push permissions, you can invoke an action sheet from the top right corner and select `Open in Browser`, then the app will also crash.

<!-- DO NOT MODIFY BELOW THIS LINE -->
<!-- ----------------------------- -->
<!-- GITPOINT_PR -->
