### PR TITLE
fix(issue): Fix wrong repository was used

### DIFF
--- a/src/issue/screens/issue.screen.js
+++ b/src/issue/screens/issue.screen.js
@@ -199,28 +199,33 @@ class Issue extends Component {
       .replace(`${v3.root}/repos/`, '')
       .replace(/([^/]+\/[^/]+)\/issues\/\d+$/, '$1');
 
-    const repoName = repository.name;
-    const owner = repository.owner.login;
-
     Promise.all([
       getIssueFromUrl(issueURL),
       getIssueComments(`${issueURL}/comments`),
-    ]).then(() => {
-      const issue = this.props.issue;
+    ])
+      .then(() => {
+        const issue = this.props.issue;
 
-      if (repository.full_name !== issueRepository) {
-        Promise.all([
-          getRepository(issue.repository_url),
-          getContributors(this.getContributorsLink(issue.repository_url)),
-        ]).then(() => {
-          this.setNavigationParams();
-        });
-      } else {
+        if (repository.full_name !== issueRepository) {
+          return Promise.all([
+            getRepository(issue.repository_url),
+            getContributors(this.getContributorsLink(issue.repository_url)),
+          ]);
+        }
+
+        return [];
+      })
+      .then(() => {
+        const { issue, repository } = this.props;
+
         this.setNavigationParams();
-      }
 
-      return getIssueEvents(owner, repoName, issue.number);
-    });
+        return getIssueEvents(
+          repository.owner.login,
+          repository.name,
+          issue.number
+        );
+      });
   };
 
   getContributorsLink = repository => `${repository}/contributors`;


### PR DESCRIPTION
<!--
  Bonjour!

  We can't express how grateful we are that you're working on making GitPoint
  better! We're thrilled to take a look at the changes you've made and merge
  them in as soon as possible. Please fill out this template to make the
  reviewal process as quick and smooth as possible. In addition, please make
  sure you remember to add yourself to the contributors list with the following
  command:

  $ yarn contributors:add

  Make sure the title of your PR follows our commit style guidelines (see other
  open PR's for reference if you're confused):

  https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines

  Thanks again for your hard work!
-->

| Question         | Response    |
| ---------------- | ----------- |
| Version?         | v1.4.0      |
| Devices tested?  | iPhone 6 simulator, iOS 11.0 |
| Bug fix?         | yes      |
| New feature?     | no      |
| Includes tests?  | no      |
| All Tests pass?  | yes      |
| Related ticket?  | #655        |

---


## Description

<!--
  What changes did you make?
-->

Fixes #655.

This bug was introduced by #438. `getIssueEvents` should not be invoked until `this.props.issue/repository` were updated.

In fact, besides the crash problem, the unfixed codes may also get wrong issue events due to `getRepository` was not returned.

<!-- DO NOT MODIFY BELOW THIS LINE -->
<!-- ----------------------------- -->
<!-- GITPOINT_PR -->
