### PR TITLE
feat(store): blacklist everything but auth from persistent storage

### DIFF
--- a/App.js
+++ b/App.js
@@ -61,14 +61,7 @@ class App extends Component {
       {
         storage: AsyncStorage,
         transforms: [encryptor],
-        blacklist: [
-          'user',
-          'issue',
-          'repository',
-          'organization',
-          'search',
-          'notifications',
-        ],
+        whitelist: ['auth'],
       },
       () => {
         this.setState({ rehydrated: true });

--- a/App.js
+++ b/App.js
@@ -61,7 +61,14 @@ class App extends Component {
       {
         storage: AsyncStorage,
         transforms: [encryptor],
-        blacklist: ['user'],
+        blacklist: [
+          'user',
+          'issue',
+          'repository',
+          'organization',
+          'search',
+          'notifications',
+        ],
       },
       () => {
         this.setState({ rehydrated: true });


### PR DESCRIPTION
| Question         | Response    |
| ---------------- | ----------- |
| Version?         | master      |
| Devices tested?  | iPhone 7, Android Nexus 5 |
| Bug fix?         | no      |
| New feature?     | no      |
| Includes tests?  | no      |
| All Tests pass?  | yes      |
| Related ticket?  | none        |

---

## Description

This PR removes everything but `auth` from the persistent storage.
Motivation is that there's no point in keeping this information, and it's sometime a pain in the A.
Example:

* Go to an issue that crashes because of some markdown problem
* Restart the app
* Go to another issue that shouldn't crash.
* App crashes because it's still parsing the old markdown from store, before getting the new one

This was partially discussed here: https://github.com/gitpoint/git-point/pull/366#discussion_r141516846

<!--
  What changes did you make?
-->


<!-- DO NOT MODIFY BELOW THIS LINE -->
<!-- ----------------------------- -->
<!-- GITPOINT_PR -->
