### PR TITLE
fix(crash): don't navigate to issue if it's a release notification

### DIFF
--- a/src/components/notification-list-item.component.js
+++ b/src/components/notification-list-item.component.js
@@ -57,6 +57,7 @@ const IconStyled = styled(Icon).attrs({
 const SubjectType = {
   commit: 'Commit',
   pull: 'PullRequest',
+  release: 'Release',
 };
 
 export class NotificationListItem extends Component {
@@ -76,6 +77,8 @@ export class NotificationListItem extends Component {
         return 'git-commit';
       case SubjectType.pull:
         return 'git-pull-request';
+      case SubjectType.release:
+        return 'tag';
       default:
         return 'issue-opened';
     }

--- a/src/components/notification-list-item.component.js
+++ b/src/components/notification-list-item.component.js
@@ -87,7 +87,8 @@ export class NotificationListItem extends Component {
   getTitleComponentProps = () => {
     const { notification, navigationAction } = this.props;
 
-    return notification.subject.type === SubjectType.commit
+    return notification.subject.type === SubjectType.commit ||
+      notification.subject.type === SubjectType.release
       ? {}
       : {
           onPress: () => navigationAction(notification),

--- a/src/notifications/screens/notifications.screen.js
+++ b/src/notifications/screens/notifications.screen.js
@@ -346,7 +346,6 @@ class Notifications extends Component {
     const { markAsRead, navigation } = this.props;
 
     markAsRead(notification.id);
-
     navigation.navigate('Issue', {
       issueURL: notification.subject.url.replace(/pulls\/(\d+)$/, 'issues/$1'),
       isPR: notification.subject.type === 'PullRequest',

--- a/src/notifications/screens/notifications.screen.js
+++ b/src/notifications/screens/notifications.screen.js
@@ -346,6 +346,14 @@ class Notifications extends Component {
     const { markAsRead, navigation } = this.props;
 
     markAsRead(notification.id);
+
+    if (
+      notification.subject.type !== 'PullRequest' &&
+      notification.subject.type !== 'Issue'
+    ) {
+      return;
+    }
+
     navigation.navigate('Issue', {
       issueURL: notification.subject.url.replace(/pulls\/(\d+)$/, 'issues/$1'),
       isPR: notification.subject.type === 'PullRequest',

--- a/src/notifications/screens/notifications.screen.js
+++ b/src/notifications/screens/notifications.screen.js
@@ -347,13 +347,6 @@ class Notifications extends Component {
 
     markAsRead(notification.id);
 
-    if (
-      notification.subject.type !== 'PullRequest' &&
-      notification.subject.type !== 'Issue'
-    ) {
-      return;
-    }
-
     navigation.navigate('Issue', {
       issueURL: notification.subject.url.replace(/pulls\/(\d+)$/, 'issues/$1'),
       isPR: notification.subject.type === 'PullRequest',


### PR DESCRIPTION
| Question         | Response    |
| ---------------- | ----------- |
| Version?         | v1.4.1      |
| Devices tested?  | iPhone 7 |
| Bug fix?         | yes      |
| New feature?     | no      |
| Includes tests?  | no      |
| All Tests pass?  | yes      |
| Related ticket?  | #667         |

---

## Description

We now only try to navigate to the issue if the `notification.subject.type` was either a `PullRequest` or an `Issue`.

We still need it to be clickable to mark the notification as read.

Also made a release notification display the accurate icon (tag).

Closes #667.


<!-- DO NOT MODIFY BELOW THIS LINE -->
<!-- ----------------------------- -->
<!-- GITPOINT_PR -->
