### PR TITLE
chore(ci): Upgrade CI Node.js version to 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ cache:
   directories:
     - node_modules
 node_js:
-  - 7
+  - 8
 script:
   - yarn run eslint && yarn run stylelint && yarn run test:coverage


### PR DESCRIPTION
> yarn run v1.3.2
warning You are using Node "7.10.1" which is not supported and may encounter bugs or unexpected behavior. Yarn supports the following semver range: "^4.8.0 || ^5.7.0 || ^6.2.2 || >=8.0.0"

The CI warns that `yarn` is not compatible with Node.js 7. We also complained that the CI is too slow. Let me try to upgrade Node.js version and compare the time.