### PR TITLE
fix: scroll to real list bottom after posting a comment

### DIFF
--- a/src/issue/screens/issue.screen.js
+++ b/src/issue/screens/issue.screen.js
@@ -255,9 +255,10 @@ class Issue extends Component {
     const owner = repository.owner.login;
     const issueNum = issue.number;
 
-    this.props.postIssueComment(body, owner, repoName, issueNum);
+    this.props.postIssueComment(body, owner, repoName, issueNum).then(() => {
+      this.commentsList.scrollToEnd();
+    });
     Keyboard.dismiss();
-    this.commentsList.scrollToEnd();
   };
 
   deleteComment = comment => {
@@ -315,6 +316,10 @@ class Issue extends Component {
   renderItem = ({ item }) => {
     const { locale, navigation } = this.props;
 
+    if (item.header) {
+      return this.renderHeader();
+    }
+
     if (item.event) {
       return <IssueEventListItem event={item} navigation={navigation} />;
     }
@@ -352,10 +357,11 @@ class Issue extends Component {
     );
     const isShowLoadingContainer =
       isPendingComments || isPendingIssue || isPendingEvents;
+    const header = { header: true, created_at: '' };
     const events = formatEventsToRender([...this.props.events]);
     const conversation = !isPendingComments
-      ? [issue, ...comments, ...events].sort(compareCreatedAt)
-      : [];
+      ? [header, issue, ...comments, ...events].sort(compareCreatedAt)
+      : [header];
 
     const participantNames = !isPendingComments
       ? conversation.map(item => item && item.user && item.user.login)
@@ -393,7 +399,6 @@ class Issue extends Component {
                 refreshing={isLoadingData}
                 onRefresh={this.getIssueInformation}
                 contentContainerStyle={{ flexGrow: 1 }}
-                ListHeaderComponent={this.renderHeader}
                 removeClippedSubviews={false}
                 data={conversation}
                 keyExtractor={this.keyExtractor}


### PR DESCRIPTION
| Question         | Response    |
| ---------------- | ----------- |
| Version?         | v1.4.1      |
| Devices tested?  | iPhone 7 |
| Bug fix?         | yes      |
| New feature?     | no      |
| Includes tests?  | no      |
| All Tests pass?  | yes      |
| Related ticket?  | #660        |

---

## Description

This is an attempt to fix the scrolling problem reported in #660. After posting the comment, the comment list didn't really scroll all the way down.

This was due to two reasons:

1. `scrollToBottom()` was fired before the api call returned the new comment
2. There is a bug in `FlatList` that fails to really scroll to bottom when using `ListComponentHeader` without implementing `getItemLayout` (that would allow to RN to compute the list height).

This PR solves 1 by scrolling when the API returns, and 2 by implementing the issue description as the first `data` entry for the list.

This is kind of "hacky", but I don't see a better way to solve this performance wise. Implementing getItemLayout() would mean rendering markdown & events just to measure heights before the list item is currently displayed on the .. 😵 

Would happily take advices for this one 🙏 

PS: Still need to be tested on Android

<!-- DO NOT MODIFY BELOW THIS LINE -->
<!-- ----------------------------- -->
<!-- GITPOINT_PR -->
