### PR TITLE
refactor(search): refactor search switch between user and repo

### DIFF
--- a/src/search/screens/search.screen.js
+++ b/src/search/screens/search.screen.js
@@ -110,6 +110,7 @@ class Search extends Component {
 
     this.state = {
       query: '',
+      currentQuery: {},
       searchType: 0,
       searchStart: false,
       searchFocus: false,
@@ -129,9 +130,12 @@ class Search extends Component {
     if (query !== '') {
       this.setState({
         searchStart: true,
+        currentQuery: {
+          ...this.state.currentQuery,
+          [selectedSearchType]: query,
+        },
         query,
       });
-
       if (selectedSearchType === 0) {
         searchRepos(query);
       } else {
@@ -145,8 +149,9 @@ class Search extends Component {
       this.setState({
         searchType: selectedType,
       });
-
-      this.search(this.state.query, selectedType);
+      if (this.state.currentQuery[selectedType] !== this.state.query) {
+        this.search(this.state.query, selectedType);
+      }
     }
   }
 


### PR DESCRIPTION
prevent sending request for same query while switching between repo and user search

<!--
  Bonjour!

  We can't express how grateful we are that you're working on making GitPoint
  better! We're thrilled to take a look at the changes you've made and merge
  them in as soon as possible. Please fill out this template to make the
  reviewal process as quick and smooth as possible. In addition, please make
  sure you remember to add yourself to the contributors list with the following
  command:

  $ yarn contributors:add

  Make sure the title of your PR follows our commit style guidelines (see other
  open PR's for reference if you're confused):

  https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines

  Thanks again for your hard work!
-->

| Question         | Response    |
| ---------------- | ----------- |
| Version?         | v1.4.1      |
| Devices tested?  | one plus5 |
| Bug fix?         | no      |
| New feature?     | no      |
| Includes tests?  | no      |
| All Tests pass?  | yes      |
| Related ticket?  |         |

---


## Description

Switching between search results of user and repo makes a new request every time even for the same query for which the result is already available. Added logic to prevent this. 

<!-- DO NOT MODIFY BELOW THIS LINE -->
<!-- ----------------------------- -->
<!-- GITPOINT_PR -->
