### PR TITLE
test: make locale test output more readable

### DIFF
--- a/__tests__/tests/others/locales.js
+++ b/__tests__/tests/others/locales.js
@@ -3,13 +3,15 @@ import keysDiff from 'keys-diff';
 import * as languages from 'locale/languages';
 
 const baseLanguage = common.defaultLocale;
-const baseTranslation = languages[baseLanguage];
 
 describe('Locales', () => {
   Object.keys(languages).forEach(key => {
     if (key === baseLanguage) return;
     it(`${key} should contain same keys as ${baseLanguage}`, () => {
-      expect(keysDiff(baseTranslation, languages[key])).toEqual([[], []]);
+      expect(keysDiff(languages[baseLanguage], languages[key])).toEqual([
+        [],
+        [],
+      ]);
     });
   });
 });

--- a/__tests__/tests/others/locales.js
+++ b/__tests__/tests/others/locales.js
@@ -1,28 +1,15 @@
 import { common } from 'config';
+import keysDiff from 'keys-diff';
 import * as languages from 'locale/languages';
 
-function createExpectedObject(object) {
-  const ret = {};
-
-  Object.keys(object).forEach(key => {
-    ret[key] =
-      typeof object[key] === 'object'
-        ? createExpectedObject(object[key])
-        : expect.stringMatching(/./);
-  });
-
-  return ret;
-}
-
 const baseLanguage = common.defaultLocale;
-const expectedObject = createExpectedObject(languages[baseLanguage]);
+const baseTranslation = languages[baseLanguage];
 
 describe('Locales', () => {
   Object.keys(languages).forEach(key => {
     if (key === baseLanguage) return;
-
     it(`${key} should contain same keys as ${baseLanguage}`, () => {
-      expect(languages[key]).toMatchObject(expectedObject);
+      expect(keysDiff(baseTranslation, languages[key])).toEqual([[], []]);
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -6,19 +6,13 @@
     "start": "react-native start",
     "start:logger": "LOGGER_ENABLED=true react-native start --reset-cache",
     "start:tron": "TRON_ENABLED=true react-native start --reset-cache",
-    "start:android":
-      "concurrently -r 'react-native start' 'yarn start:android:no-packager'",
-    "start:android:logger":
-      "LOGGER_ENABLED=true concurrently -r 'react-native start --reset-cache' 'yarn start:android:no-packager'",
-    "start:android:tron":
-      "TRON_ENABLED=true concurrently -r 'react-native start --reset-cache' 'yarn start:android:no-packager'",
+    "start:android": "concurrently -r 'react-native start' 'yarn start:android:no-packager'",
+    "start:android:logger": "LOGGER_ENABLED=true concurrently -r 'react-native start --reset-cache' 'yarn start:android:no-packager'",
+    "start:android:tron": "TRON_ENABLED=true concurrently -r 'react-native start --reset-cache' 'yarn start:android:no-packager'",
     "start:android:no-packager": "react-native run-android --no-packager",
-    "start:ios":
-      "concurrently -r 'react-native start' 'yarn start:ios:no-packager'",
-    "start:ios:logger":
-      "LOGGER_ENABLED=true concurrently -r 'react-native start --reset-cache' 'yarn start:ios:no-packager'",
-    "start:ios:tron":
-      "TRON_ENABLED=true concurrently -r 'react-native start --reset-cache' 'yarn start:ios:no-packager'",
+    "start:ios": "concurrently -r 'react-native start' 'yarn start:ios:no-packager'",
+    "start:ios:logger": "LOGGER_ENABLED=true concurrently -r 'react-native start --reset-cache' 'yarn start:ios:no-packager'",
+    "start:ios:tron": "TRON_ENABLED=true concurrently -r 'react-native start --reset-cache' 'yarn start:ios:no-packager'",
     "start:ios:no-packager": "react-native run-ios --no-packager",
     "clean": "rm -rf node_modules",
     "clean:android": "cd android && ./gradlew clean && cd -",
@@ -42,21 +36,20 @@
     "cp-release:ios": "code-push release-react git-point-ios ios",
     "cp-release:android": "code-push release-react git-point-android android",
     "cp-promote:ios": "code-push promote git-point-ios Staging Production",
-    "cp-promote:android":
-      "code-push promote git-point-android Staging Production",
-    "cp-history:ios-staging":
-      "code-push deployment history git-point-ios Staging",
-    "cp-history:android-staging":
-      "code-push deployment history git-point-android Staging",
-    "cp-history:android-production":
-      "code-push deployment history git-point-android Production",
-    "cp-history:ios-production":
-      "code-push deployment history git-point-ios Production",
+    "cp-promote:android": "code-push promote git-point-android Staging Production",
+    "cp-history:ios-staging": "code-push deployment history git-point-ios Staging",
+    "cp-history:android-staging": "code-push deployment history git-point-android Staging",
+    "cp-history:android-production": "code-push deployment history git-point-android Production",
+    "cp-history:ios-production": "code-push deployment history git-point-ios Production",
     "doctoc": "doctoc --title='## Table of Contents' README.md",
     "postinstall": "opencollective postinstall"
   },
   "lint-staged": {
-    "*.js": ["prettier --write", "git add", "eslint --cache"]
+    "*.js": [
+      "prettier --write",
+      "git add",
+      "eslint --cache"
+    ]
   },
   "dependencies": {
     "date-fns": "^1.29.0",
@@ -85,8 +78,7 @@
     "react-native-i18n": "^2.0.4",
     "react-native-linear-gradient": "^2.4.0",
     "react-native-material-design-searchbar": "^1.1.4",
-    "react-native-mock":
-      "https://github.com/shqld/react-native-mock/tarball/master",
+    "react-native-mock": "https://github.com/shqld/react-native-mock/tarball/master",
     "react-native-parallax-scroll-view": "^0.20.1",
     "react-native-photo-view": "^1.5.2",
     "react-native-safari-view": "^2.0.0",
@@ -133,6 +125,7 @@
     "flow-bin": "^0.47.0",
     "husky": "^0.14.3",
     "jest": "^21.2.1",
+    "keys-diff": "^1.0.5",
     "lint-staged": "^3.2.6",
     "minicat": "^1.0.0",
     "prettier": "^1.7.4",
@@ -148,18 +141,23 @@
   },
   "jest": {
     "preset": "react-native",
-    "testMatch": ["**/__tests__/tests/**/*.js"],
-    "setupFiles": ["./testenv.js"],
+    "testMatch": [
+      "**/__tests__/tests/**/*.js"
+    ],
+    "setupFiles": [
+      "./testenv.js"
+    ],
     "transformIgnorePatterns": [
       "node_modules/(?!(jest-)?react-native|react-navigation)"
     ],
     "moduleNameMapper": {
-      "styled-components":
-        "<rootDir>/node_modules/styled-components/dist/styled-components.native.cjs.js"
+      "styled-components": "<rootDir>/node_modules/styled-components/dist/styled-components.native.cjs.js"
     }
   },
   "rnpm": {
-    "assets": ["./src/assets/fonts"]
+    "assets": [
+      "./src/assets/fonts"
+    ]
   },
   "config": {
     "commitizen": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -255,6 +255,10 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+argv@>=0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/argv/-/argv-0.0.2.tgz#ecbd16f8949b157183711b1bda334f37840185ab"
+
 aria-query@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-0.7.0.tgz#4af10a1e61573ddea0cf3b99b51c52c05b424d24"
@@ -1663,6 +1667,15 @@ code-push@2.0.4:
     superagent-proxy "^1.0.0"
     yazl "^2.4.1"
 
+codecov@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/codecov/-/codecov-1.0.1.tgz#97260ceac0e96b8eda8d562006558a53a139dffd"
+  dependencies:
+    argv ">=0.0.2"
+    execSync "1.0.2"
+    request ">=2.42.0"
+    urlgrey ">=0.4.0"
+
 collapse-white-space@^1.0.0, collapse-white-space@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/collapse-white-space/-/collapse-white-space-1.0.3.tgz#4b906f670e5a963a87b76b0e1689643341b6023c"
@@ -2746,6 +2759,12 @@ exec-sh@^0.2.0:
   dependencies:
     merge "^1.1.3"
 
+execSync@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/execSync/-/execSync-1.0.2.tgz#1f42eda582225180053224ecdd3fd1960fdb3139"
+  dependencies:
+    temp "~0.5.1"
+
 execa@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
@@ -3290,6 +3309,10 @@ gonzales-pe@^4.0.3:
 graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.4, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
+
+graceful-fs@~1:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-1.2.3.tgz#15a4806a57547cb2d2dbf27f42e89a8c3451b364"
 
 growly@^1.3.0:
   version "1.3.0"
@@ -4431,6 +4454,12 @@ jsx-ast-utils@^2.0.1:
 keymirror@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/keymirror/-/keymirror-0.1.1.tgz#918889ea13f8d0a42e7c557250eee713adc95c35"
+
+keys-diff@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/keys-diff/-/keys-diff-1.0.5.tgz#b6539a5021681101d19f94d71e40d74bff24c18c"
+  dependencies:
+    codecov "^1.0.1"
 
 kind-of@^3.0.2:
   version "3.2.2"
@@ -6759,7 +6788,7 @@ request@2.81.0:
     tunnel-agent "^0.6.0"
     uuid "^3.0.0"
 
-request@^2.72.0, request@^2.79.0:
+request@>=2.42.0, request@^2.72.0, request@^2.79.0:
   version "2.83.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.83.0.tgz#ca0b65da02ed62935887808e6f510381034e3356"
   dependencies:
@@ -6879,6 +6908,12 @@ rimraf@2, rimraf@2.x.x, rimraf@^2.2.8, rimraf@^2.5.1, rimraf@^2.5.4, rimraf@^2.6
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:
     glob "^7.0.5"
+
+rimraf@~2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.1.4.tgz#5a6eb62eeda068f51ede50f29b3e5cd22f3d9bb2"
+  optionalDependencies:
+    graceful-fs "~1"
 
 rimraf@~2.2.6:
   version "2.2.8"
@@ -7609,6 +7644,12 @@ temp@0.8.3:
     os-tmpdir "^1.0.0"
     rimraf "~2.2.6"
 
+temp@~0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/temp/-/temp-0.5.1.tgz#77ab19c79aa7b593cbe4fac2441768cad987b8df"
+  dependencies:
+    rimraf "~2.1.4"
+
 test-exclude@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-4.1.1.tgz#4d84964b0966b0087ecc334a2ce002d3d9341e26"
@@ -7905,6 +7946,10 @@ unpipe@1.0.0, unpipe@~1.0.0:
 update-section@^0.3.0:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/update-section/-/update-section-0.3.3.tgz#458f17820d37820dc60e20b86d94391b00123158"
+
+urlgrey@>=0.4.0:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/urlgrey/-/urlgrey-0.4.4.tgz#892fe95960805e85519f1cd4389f2cb4cbb7652f"
 
 user-home@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
## Description

I was looking at the travis-ci build output for a failure on #638 to try to figure out the problem, and I found it to be really unhelpful as it generates **~600** lines of diff like this when there's a key mismatch

<img width="413" alt="screen shot 2018-02-01 at 8 25 30 pm" src="https://user-images.githubusercontent.com/304450/35698794-6fd7f3ae-078e-11e8-8fb3-72b2fc411bcb.png">

full log [here](https://travis-ci.org/gitpoint/git-point/builds/336108646). It's almost impossible to tell which keys are missing.

changed the test to use `keys-diff` for a minimalistic straight-forward output:

<img width="379" alt="screen shot 2018-02-01 at 8 29 02 pm" src="https://user-images.githubusercontent.com/304450/35699053-29f976e0-078f-11e8-916d-9c16d12d0392.png">



<!-- DO NOT MODIFY BELOW THIS LINE -->
<!-- ----------------------------- -->
<!-- GITPOINT_PR -->
