### PR TITLE
fix: remove extra spaces from empty text nodes

### DIFF
--- a/src/components/github-htmlview.component.js
+++ b/src/components/github-htmlview.component.js
@@ -300,7 +300,8 @@ export class GithubHtmlView extends Component {
               <Text
                 style={linkStyle}
                 onPress={() =>
-                  onLinkPress({ ...node, attribs: { href: node.attribs.src } })}
+                  onLinkPress({ ...node, attribs: { href: node.attribs.src } })
+                }
               >
                 [{node.attribs.alt}]
                 {'\n'}
@@ -388,13 +389,13 @@ export class GithubHtmlView extends Component {
       };
 
       if (_node.type === 'text') {
-        if (_node.data === '\n') {
+        if (_node.data.trim() === '' && _node.data.includes('\n')) {
           return (
             <Text
               key={_index}
               style={{ height: 8, fontSize: normalize(8), width: 2 }}
             >
-              {_node.data}
+              {'\n'}
             </Text>
           );
         }


### PR DESCRIPTION

| Question         | Response    |
| ---------------- | ----------- |
| Version?         | v1.4.1      |
| Devices tested?  | iPhone 7... |
| Bug fix?         | yes      |
| New feature?     | no      |
| Includes tests?  | no      |
| All Tests pass?  | yes      |
| Related ticket?  | #728         |

---

## Screenshots


| Before   | After    |
| -------- | -------- |
| ![simulator screen shot - iphone 6 - 2018-02-14 at 10 55 53](https://user-images.githubusercontent.com/304450/36198571-36f6c7b6-1177-11e8-8dd0-96c8d893233c.png) |  ![simulator screen shot - iphone 6 - 2018-02-14 at 11 00 26](https://user-images.githubusercontent.com/304450/36198575-3e82f6f8-1177-11e8-9b92-4f90d34d9569.png) |

## Description

Instead of testing that the content of the text chunk if "\n" to replace it with our own vertical spacer, I now make sure that trim(text) is empty and it contains at least one "\n".

GitHub probably changed from "\n" to "_space_\n" or something like that, which made the previous implemented test fail.

<!-- DO NOT MODIFY BELOW THIS LINE -->
<!-- ----------------------------- -->
<!-- GITPOINT_PR -->
