### PR TITLE
fix(login): Provide an escape hatch for Android

### DIFF
--- a/src/auth/screens/login.screen.js
+++ b/src/auth/screens/login.screen.js
@@ -22,7 +22,7 @@ import { ViewContainer, ErrorScreen } from 'components';
 import { colors, fonts, normalize } from 'config';
 import { CLIENT_ID } from 'api';
 import { auth, getUser } from 'auth';
-import { translate, resetNavigationTo } from 'utils';
+import { openURLInView, translate, resetNavigationTo } from 'utils';
 
 let stateRandom = Math.random().toString();
 
@@ -103,6 +103,11 @@ const styles = StyleSheet.create({
     flex: 2,
     justifyContent: 'center',
     alignItems: 'center',
+  },
+  troublesLink: {
+    color: colors.greyLight,
+    paddingTop: 20,
+    fontStyle: 'italic',
   },
   signInContainer: {
     position: 'absolute',
@@ -259,6 +264,7 @@ class Login extends Component {
 
   render() {
     const { locale, isLoggingIn, hasInitialUser } = this.props;
+    const loginUrl = `https://github.com/login/oauth/authorize?response_type=token&client_id=${CLIENT_ID}&redirect_uri=gitpoint://welcome&scope=user%20repo&state=${stateRandom}`;
 
     return (
       <ViewContainer>
@@ -352,7 +358,7 @@ class Login extends Component {
               <View style={styles.browserSection}>
                 <WebView
                   source={{
-                    uri: `https://github.com/login/oauth/authorize?response_type=token&client_id=${CLIENT_ID}&redirect_uri=gitpoint://welcome&scope=user%20repo&state=${stateRandom}`,
+                    uri: loginUrl,
                   }}
                   renderError={() => <ErrorScreen locale={locale} />}
                   onLoadStart={e => this.toggleCancelButton(e, true)}
@@ -371,6 +377,14 @@ class Login extends Component {
                   textStyle={styles.buttonText}
                   onPress={() => this.setModalVisible(!this.state.modalVisible)}
                 />
+                {Platform.OS === 'android' && (
+                  <Text
+                    style={styles.troublesLink}
+                    onPress={() => openURLInView(loginUrl)}
+                  >
+                    {translate('auth.login.troubles', locale)}
+                  </Text>
+                )}
               </View>
             </View>
           </Modal>

--- a/src/locale/languages/de.js
+++ b/src/locale/languages/de.js
@@ -7,6 +7,7 @@ export const de = {
       connectingToGitHub: 'Verbinde mit GitHub...',
       preparingGitPoint: 'Bereite GitPoint vor...',
       cancel: 'ABBRECHEN',
+      troubles: "Can't login?",
       welcomeTitle: 'Willkommen bei GitPoint',
       welcomeMessage:
         'Der umfangreichste GitHub Client der zu 100% kostenlos ist',

--- a/src/locale/languages/en.js
+++ b/src/locale/languages/en.js
@@ -7,6 +7,7 @@ export const en = {
       connectingToGitHub: 'Connecting to GitHub...',
       preparingGitPoint: 'Preparing GitPoint...',
       cancel: 'CANCEL',
+      troubles: "Can't login?",
       welcomeTitle: 'Welcome to GitPoint',
       welcomeMessage: 'The most feature-rich GitHub client that is 100% free',
       notificationsTitle: 'Control notifications',

--- a/src/locale/languages/eo.js
+++ b/src/locale/languages/eo.js
@@ -4,6 +4,7 @@ export const eo = {
       connectingToGitHub: 'Konektante al GitHub...',
       preparingGitPoint: 'Prepari GitPoint...',
       cancel: 'CANCELO',
+      troubles: "Can't login?",
       welcomeTitle: 'Bonvenon al GitPoint',
       welcomeMessage:
         'La plej karakterizaĵo riĉa GitHub-kliento, kiu estas 100% libera',

--- a/src/locale/languages/es.js
+++ b/src/locale/languages/es.js
@@ -7,6 +7,7 @@ export const es = {
       connectingToGitHub: 'Conectando a GitHub...',
       preparingGitPoint: 'Preparando GitPoint...',
       cancel: 'CANCELAR',
+      troubles: "Can't login?",
       welcomeTitle: 'Bienvenido a GitPoint',
       welcomeMessage:
         'El cliente GitHub con más funcionalidades, 100% gratuito',

--- a/src/locale/languages/eu.js
+++ b/src/locale/languages/eu.js
@@ -4,6 +4,7 @@ export const eu = {
       connectingToGitHub: 'GitHubera konektatzen...',
       preparingGitPoint: 'GitPoint prestatzen...',
       cancel: 'EZEZTATU',
+      troubles: "Can't login?",
       welcomeTitle: 'Ongi etorri GitPointera',
       welcomeMessage:
         'Funtzionalitate gehien dituen GitHub bezeroa,%100 doakoa',

--- a/src/locale/languages/fr.js
+++ b/src/locale/languages/fr.js
@@ -5,6 +5,7 @@ export const fr = {
       connectingToGitHub: 'Connexion à GitHub...',
       preparingGitPoint: 'Configuration de GitPoint...',
       cancel: 'ANNULER',
+      troubles: 'Problème de connexion ?',
       welcomeTitle: 'Bienvenue dans GitPoint',
       welcomeMessage:
         'Le client GitHub le plus riche en fonctionnalités tout en étant 100% gratuit',

--- a/src/locale/languages/gl.js
+++ b/src/locale/languages/gl.js
@@ -4,6 +4,7 @@ export const gl = {
       connectingToGitHub: 'Conectando con GitHub...',
       preparingGitPoint: 'Preparando GitPoint...',
       cancel: 'CANCELAR',
+      troubles: "Can't login?",
       welcomeTitle: 'Benvido a GitPoint',
       welcomeMessage: 'O cliente de GitHub con máis funcións que é 100% gratis',
       notificationsTitle: 'Controlar notificacións',

--- a/src/locale/languages/nl.js
+++ b/src/locale/languages/nl.js
@@ -4,6 +4,7 @@ export const nl = {
       connectingToGitHub: 'Verbinding maken met GitHub ...', // google translate
       preparingGitPoint: 'GitPoint voorbereiden ...', // google translate
       cancel: 'ANNULEER', // google translate
+      troubles: "Can't login?",
       welcomeTitle: 'Welkom bij GitPoint',
       welcomeMessage: 'De meest complete GitHub client die geen geld kost',
       notificationsTitle: 'Beheer notificaties',

--- a/src/locale/languages/pl.js
+++ b/src/locale/languages/pl.js
@@ -4,6 +4,7 @@ export const pl = {
       connectingToGitHub: 'Łączenie z GitHubem...',
       preparingGitPoint: 'Przygotowanie GitPoint...',
       cancel: 'ANULUJ',
+      troubles: "Can't login?",
       welcomeTitle: 'Witaj w GitPoint',
       welcomeMessage: 'Najlepsza integracja z GitHubem jest 100% za darmo',
       notificationsTitle: 'Kontrola notyfikacji',

--- a/src/locale/languages/pt-br.js
+++ b/src/locale/languages/pt-br.js
@@ -4,6 +4,7 @@ export const ptBR = {
       connectingToGitHub: 'Conectando ao GitHub...',
       preparingGitPoint: 'Preparando GitPoint...',
       cancel: 'CANCELAR',
+      troubles: "Can't login?",
       welcomeTitle: 'Bem-vindo ao GitPoint',
       welcomeMessage:
         'O GitHub client com a maior quantidade de funcionalidades que é 100% grátis',

--- a/src/locale/languages/pt.js
+++ b/src/locale/languages/pt.js
@@ -4,6 +4,7 @@ export const pt = {
       connectingToGitHub: ' GitHub...',
       preparingGitPoint: 'A Preparar o GitPoint...',
       cancel: 'CANCELAR',
+      troubles: "Can't login?",
       welcomeTitle: 'Bem-vindo ao GitPoint',
       welcomeMessage:
         'O cliente de GitHub com mais funcionalidades, 100% grátis',

--- a/src/locale/languages/ru.js
+++ b/src/locale/languages/ru.js
@@ -4,6 +4,7 @@ export const ru = {
       connectingToGitHub: 'Подключение к GitHub...',
       preparingGitPoint: 'Подготовка GitPoint...',
       cancel: 'ОТМЕНА',
+      troubles: "Can't login?",
       welcomeTitle: 'Добро пожаловать в GitPoint',
       welcomeMessage: 'Самый многофункциональный бесплатный GitHub-клиент',
       notificationsTitle: 'Управление уведомлениями',

--- a/src/locale/languages/tr.js
+++ b/src/locale/languages/tr.js
@@ -4,6 +4,7 @@ export const tr = {
       connectingToGitHub: "GitHub'a Bağlanılıyor...",
       preparingGitPoint: 'GitPoint Hazırlanıyor...',
       cancel: 'İPTAL',
+      troubles: "Can't login?",
       welcomeTitle: "GitPoint'e Hoşgeldiniz",
       welcomeMessage:
         "En zengin özelliklere sahip GitHub client'ı ve 100% ücretsiz",

--- a/src/locale/languages/uk.js
+++ b/src/locale/languages/uk.js
@@ -4,6 +4,7 @@ export const uk = {
       connectingToGitHub: 'Підключення до GitHub...',
       preparingGitPoint: 'Підготовка GitPoint...',
       cancel: 'ВІДМІНИТИ',
+      troubles: "Can't login?",
       welcomeTitle: 'Ласкаво просмо в GitPoint',
       welcomeMessage: 'Найбільш багатофункціональни безплатний GitHub-клієнт',
       notificationsTitle: 'Керування сповіщеннями',

--- a/src/locale/languages/zh-cn.js
+++ b/src/locale/languages/zh-cn.js
@@ -7,6 +7,7 @@ export const zhCN = {
       connectingToGitHub: '正在连接GitHub...',
       preparingGitPoint: 'GitPoint准备中...',
       cancel: '取消',
+      troubles: "Can't login?",
       welcomeTitle: '欢迎来到GitPoint',
       welcomeMessage: '完全免费，功能最强大的GitHub客户端!',
       notificationsTitle: '通知设定',

--- a/src/locale/languages/zh-tw.js
+++ b/src/locale/languages/zh-tw.js
@@ -4,6 +4,7 @@ export const zhTW = {
       connectingToGitHub: '連線至 GitHub...',
       preparingGitPoint: 'GitPoint 準備中...',
       cancel: '取消',
+      troubles: "Can't login?",
       welcomeTitle: '歡迎使用 GitPoint',
       welcomeMessage: '完全免費，功能最強大的 GitHub 應用程式！',
       notificationsTitle: '通知設定',


### PR DESCRIPTION
| Question         | Response    |
| ---------------- | ----------- |
| Version?         | v1.4.1      |
| Devices tested?  | OnePlus 5t |
| Bug fix?         | yes     |
| New feature?     | no      |
| Includes tests?  | no      |
| All Tests pass?  | yes      |
| Related ticket?  | #732 #674 #680    |

---

## Screenshots


| Before   | After    |
| -------- | -------- |
| ![screenshot_20180324-125009](https://user-images.githubusercontent.com/304450/37863793-6ea05b86-2f64-11e8-92c6-2a4c79fc4282.jpg) | ![screenshot_20180324-124806](https://user-images.githubusercontent.com/304450/37863795-738620f4-2f64-11e8-970d-4e9a54e786de.jpg) |


## Description

Some users complained about the "Login" button being disabled in the WebView. 
This is because GitHub disables it from some old/stock android browsers.

This PR simply adds a link to open the oAuth screen in an external browser, so that the user can decide which browser to use and finalize the login step. Tested and confirmed in #732.

<!-- DO NOT MODIFY BELOW THIS LINE -->
<!-- ----------------------------- -->
<!-- GITPOINT_PR -->
