### PR TITLE
fix: add a Proxy polyfill to make sure it's available everywhere

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "normalizr": "^3.2.4",
     "opencollective": "^1.0.3",
     "parse-diff": "^0.4.0",
+    "proxy-polyfill": "0.1.6",
     "query-string": "^5.0.1",
     "react": "16.2.0",
     "react-native": "0.52.0",

--- a/src/api/proxies/create-dispatch-proxy.js
+++ b/src/api/proxies/create-dispatch-proxy.js
@@ -1,5 +1,6 @@
 import * as Actions from 'api/actions';
 import { normalize } from 'normalizr';
+import 'proxy-polyfill';
 
 import {
   getActionKeyFromArgs,
@@ -11,7 +12,7 @@ import {
 export const createDispatchProxy = Provider => {
   const client = new Provider();
 
-  return new Proxy(createDispatchProxy, {
+  return new Proxy(client, {
     get: (c, namespace) => {
       return new Proxy(client[namespace], {
         get: (endpoint, method) => (...args) => (dispatch, getState) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6472,6 +6472,10 @@ proxy-agent@2:
     pac-proxy-agent "^2.0.0"
     socks-proxy-agent "^3.0.0"
 
+proxy-polyfill@0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/proxy-polyfill/-/proxy-polyfill-0.1.6.tgz#ef41ec6c66f534db15db36c54493a62d184b364e"
+
 pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"


### PR DESCRIPTION
## Description

@MrZhang123 reported on gitter that he wasn't able to run the project anymore on Genymotion, due to the lack of ES6 Proxies in this environment.

This PR adds a polyfill. Tested and validated on a Genymotion 6.0.0 (api 23) player.

I've did a lot of googling about whether or not RN supports proxies in all targets for the Release build, and after reading a bunch of stuff, all I'm certain of is that I'm really uncertain. I would be really thankful if anyone could provide a clear explanation about this. 🙏 

<!-- DO NOT MODIFY BELOW THIS LINE -->
<!-- ----------------------------- -->
<!-- GITPOINT_PR -->
