### PR TITLE
feat: Add LoadingEventListItem

### DIFF
--- a/src/auth/screens/events.screen.js
+++ b/src/auth/screens/events.screen.js
@@ -3,9 +3,9 @@
 import React, { Component } from 'react';
 import styled from 'styled-components';
 import { connect } from 'react-redux';
-import { Text, FlatList, View, ActivityIndicator } from 'react-native';
+import { Text, FlatList, View } from 'react-native';
 
-import { LoadingUserListItem, UserListItem, ViewContainer } from 'components';
+import { LoadingEventListItem, UserListItem, ViewContainer } from 'components';
 import { colors, fonts, normalize } from 'config';
 import { emojifyText, translate, relativeTimeToNow } from 'utils';
 import { getNotificationsCount } from 'notifications';
@@ -508,15 +508,7 @@ class Events extends Component {
       return null;
     }
 
-    return (
-      <View
-        style={{
-          paddingVertical: 20,
-        }}
-      >
-        <ActivityIndicator animating size="large" />
-      </View>
-    );
+    return <LoadingEventListItem />;
   };
 
   render() {
@@ -530,10 +522,10 @@ class Events extends Component {
     const linebreaksPattern = /(\r\n|\n|\r)/gm;
     let content;
 
-    if (userEventsPagination.isFetching && !userEvents) {
+    if (userEventsPagination.isFetching && userEvents.length === 0) {
       content = [...Array(15)].map((item, index) => {
         // eslint-disable-next-line react/no-array-index-key
-        return <LoadingUserListItem key={index} />;
+        return <LoadingEventListItem key={index} />;
       });
     } else if (
       !userEventsPagination.isFetching &&

--- a/src/components/loading-indicators/index.js
+++ b/src/components/loading-indicators/index.js
@@ -1,4 +1,5 @@
 export * from './loading-container.component';
+export * from './loading-event-list-item.component';
 export * from './loading-members-list.component';
 export * from './loading-repository-list-item.component';
 export * from './loading-repository-profile.component';

--- a/src/components/loading-indicators/loading-event-list-item.component.js
+++ b/src/components/loading-indicators/loading-event-list-item.component.js
@@ -1,0 +1,79 @@
+import React, { Component } from 'react';
+import { Animated } from 'react-native';
+import styled from 'styled-components';
+import { colors } from 'config';
+import { infiniteAnimation } from 'utils';
+
+const Container = styled.View`
+  padding: 10px 10px 10px 0;
+  border-bottom-width: 1px;
+  border-bottom-color: #ededed;
+  background-color: transparent;
+`;
+
+const Wrapper = styled.View`
+  flex-direction: row;
+  margin-left: 10px;
+  align-items: center;
+`;
+
+const Avatar = styled(Animated.View)`
+  width: 34px;
+  height: 34px;
+  background-color: ${colors.greyDark};
+  border-radius: 17px;
+  margin-right: 10px;
+`;
+
+const Icon = styled(Animated.View)`
+  width: 16px;
+  height: 16px;
+  background-color: ${colors.greyDark};
+  margin-left: 10px;
+  margin-right: 5px;
+  border-radius: 8px;
+`;
+
+const TextBar = styled(Animated.View)`
+  height: 7px;
+  flex: 1;
+  background-color: ${colors.greyDark};
+`;
+
+export class LoadingEventListItem extends Component {
+  constructor() {
+    super();
+    this.fadeFrom = 0.3;
+    this.fadeTo = 0.6;
+    this.state = {
+      fadeAnimValue: new Animated.Value(this.fadeTo),
+    };
+  }
+
+  componentDidMount() {
+    this.runAnimation();
+  }
+
+  runAnimation() {
+    infiniteAnimation(
+      this.state.fadeAnimValue,
+      this.fadeFrom,
+      this.fadeTo,
+      () => {
+        this.runAnimation();
+      }
+    );
+  }
+
+  render() {
+    return (
+      <Container>
+        <Wrapper>
+          <Avatar style={{ opacity: this.state.fadeAnimValue }} />
+          <TextBar style={{ opacity: this.state.fadeAnimValue }} />
+          <Icon style={{ opacity: this.state.fadeAnimValue }} />
+        </Wrapper>
+      </Container>
+    );
+  }
+}

--- a/src/components/loading-indicators/loading-event-list-item.component.js
+++ b/src/components/loading-indicators/loading-event-list-item.component.js
@@ -5,7 +5,7 @@ import { colors } from 'config';
 import { infiniteAnimation } from 'utils';
 
 const Container = styled.View`
-  padding: 10px 10px 10px 0;
+  padding: 10px 10px 0;
   border-bottom-width: 1px;
   border-bottom-color: #ededed;
   background-color: transparent;

--- a/src/utils/loading-animation.js
+++ b/src/utils/loading-animation.js
@@ -19,3 +19,25 @@ export const loadingAnimation = state => {
 
   return Animated.sequence(animatedTimings);
 };
+
+export const infiniteAnimation = (state, fromValue, toValue, onEnd) => {
+  const animatedTimings = [];
+  const duration = 1000;
+
+  animatedTimings.push(
+    Animated.timing(state, {
+      toValue: fromValue,
+      duration,
+    })
+  );
+  animatedTimings.push(
+    Animated.timing(state, {
+      toValue,
+      duration,
+    })
+  );
+
+  return Animated.sequence(animatedTimings).start(() => {
+    onEnd();
+  });
+};


### PR DESCRIPTION
| Question         | Response    |
| ---------------- | ----------- |
| Version?         | v1.4.1      |
| Devices tested?  | iPhone 7, OnePlus5T |
| Bug fix?         | no      |
| New feature?     | yes      |
| Includes tests?  | no      |
| All Tests pass?  | yes      |
| Related ticket?  | none        |

---

## Screenshots

| Before   | After    |
| -------- | -------- |
| ![simulator screen shot - iphone 6 - 2018-04-02 at 13 05 11](https://user-images.githubusercontent.com/304450/38195665-82856a60-3676-11e8-951e-97019c1cbd1c.png)|![simulator screen shot - iphone 6 - 2018-04-02 at 12 57 10](https://user-images.githubusercontent.com/304450/38195674-8fba4d04-3676-11e8-9b4b-a19908a52fff.png)|


## Description

Created a new `<LoadingEventListItem />` component used as a placeholder in the events screen.

Prior to the Redux refactoring, the events screen was using `<LoadingUserListItem />` which was missing the icon placeholder. During the refactoring, this got lost due to a silly mistake on my side.

Also, when reaching the list bottom, instead of displaying the boring `<ActivityIndicator />`, we're now using this new loader, which matches the expected content :

<img width="375" alt="screen shot 2018-04-02 at 12 52 06 pm" src="https://user-images.githubusercontent.com/304450/38195713-da48ddae-3676-11e8-99be-8ed3473fc976.png">

---

While setting this new component up, I noticed that after a page or two, it wasn't animating anymore. This is due to the current implementation of `loadingAnimation` that only animated 10 times, then stopped.

Since we'll be seeing this component a lot of time in the list (every time we hit bottom), we needed a truly infinite animation. This is implemented by `infiniteAnimation`, which takes a callback so that we can start the animation again when it ends.

---

@chinesedfan since you're our styled-component expert, I'd really love if you could give `<LoadingEventListItem />` a deeper look. I wasn't able to handle the `opacity` prop using SC, so I'm setting it from the `style` prop.

Once we agree on how this should be done, I think we can use this new component as an example to migrate other loading indicators (adding them to #532 now)

<!-- DO NOT MODIFY BELOW THIS LINE -->
<!-- ----------------------------- -->
<!-- GITPOINT_PR -->
