### PR TITLE
refactor: rewrite proxy <=> client internals

### DIFF
--- a/src/api/client.js
+++ b/src/api/client.js
@@ -1,4 +1,37 @@
+// @flow
+
+import { Schema } from 'normalizr';
+import { merge } from 'lodash';
+import { version } from 'package.json';
+import { Platform } from 'react-native';
+
 import Schemas from './schemas';
+
+type SpecialParameters = {
+  forceRefresh?: boolean,
+  loadMore?: boolean,
+  perPage?: number,
+};
+
+type FetchParameters = {
+  method?: string,
+  headers?: Object,
+  body?: Object,
+};
+
+export type CallParameters = {
+  endpoint: string,
+  schema: Schema,
+  params: SpecialParameters,
+  fetchParameters?: FetchParameters,
+  normalizrKey?: string,
+  paginationArgs?: Array<string | number | boolean>,
+  entityId?: String | number,
+};
+
+export type CallType = CallParameters & {
+  type: string,
+};
 
 export class Client {
   API_ROOT = 'https://api.github.com/';
@@ -17,54 +50,73 @@ export class Client {
     POST: 'POST',
   };
 
+  Accept = {
+    DIFF: 'application/vnd.github.v3.diff+json',
+    FULL: 'application/vnd.github.v3.full+json',
+    HTML: 'application/vnd.github.v3.html+json',
+    JSON: 'application/vnd.github.v3+json',
+    MERCY_PREVIEW: 'application/vnd.github.mercy-preview+json',
+    RAW: 'application/vnd.github.v3.raw+json',
+  };
+
   authHeaders = {};
 
   call = async (
-    url,
-    params = {},
-    { method = this.Method.GET, body = {}, headers = {} } = {}
+    url: string,
+    params: SpecialParameters = {},
+    fetchParameters: FetchParameters = {}
   ) => {
-    let finalUrl;
+    let finalUrl = url;
 
-    if (params.url) {
-      // a different url was provided, use it instead (paginated)
-      finalUrl = params.url;
-    } else {
-      finalUrl = url;
-      // add explicitely specified parameters
-      if (params.per_page) {
-        finalUrl = `${finalUrl}${finalUrl.includes('?') ? '&' : '?'}per_page=${
-          params.per_page
-        }`;
-      }
+    // add explicitely specified parameters
+    if (params.perPage) {
+      finalUrl = `${finalUrl}${
+        finalUrl.includes('?') ? '&' : '?'
+      }per_page=${Number(params.perPage).toString()}`;
     }
 
     if (!finalUrl.includes(this.API_ROOT)) {
       finalUrl = `${this.API_ROOT}${finalUrl}`;
     }
 
-    const parameters = {
+    const { method, headers, body } = fetchParameters;
+
+    const parameters: any = {
       method,
       headers: {
+        'User-Agent': `GitPoint/${version} ${Platform.OS}`,
         'Cache-Control': 'no-cache',
         ...this.authHeaders,
         ...headers,
       },
     };
 
-    const withBody = [this.Method.PUT, this.Method.PATCH, this.Method.POST];
-
-    if (withBody.indexOf(method) !== -1) {
+    if (body) {
       parameters.body = JSON.stringify(body);
-      if (method === this.Method.PUT) {
-        parameters.headers['Content-Length'] = 0;
-      }
     }
 
     return fetch(finalUrl, parameters);
   };
 
-  /* eslint-disable no-unused-vars */
+  get = ({ fetchParameters, ...config }: CallParameters): CallType => ({
+    type: 'get',
+    params: {},
+    ...config,
+    fetchParameters: merge(
+      { method: this.Method.GET, headers: { Accept: this.Accept.JSON } },
+      fetchParameters
+    ),
+  });
+
+  list = ({ fetchParameters, ...config }: CallParameters): CallType => ({
+    type: 'list',
+    params: {},
+    ...config,
+    fetchParameters: merge(
+      { method: this.Method.GET, headers: { Accept: this.Accept.JSON } },
+      fetchParameters
+    ),
+  });
 
   /**
    * Sets the authorization headers given an access token.
@@ -72,7 +124,7 @@ export class Client {
    * @abstract
    * @param {string} token The oAuth access token
    */
-  setAuthHeaders = token => {
+  setAuthHeaders = (token: string) => {
     this.authHeaders = { Authorization: `token ${token}` };
   };
 
@@ -82,7 +134,7 @@ export class Client {
    * @async
    * @param {Response} response
    */
-  getCount = async response => {
+  getCount = async (response: Response) => {
     if (!response.ok) {
       return 0;
     }
@@ -104,7 +156,7 @@ export class Client {
       });
   };
 
-  getNextPageUrl = response => {
+  getNextPageUrl = (response: Response) => {
     const { headers } = response;
     const link = headers.get('link');
     const nextLink = link
@@ -130,55 +182,60 @@ export class Client {
      *
      * @param {string} userId
      */
-    getEventsReceived: async (userId, params) => {
-      return this.call(`users/${userId}/received_events`, params).then(
-        response => ({
-          response,
-          nextPageUrl: this.getNextPageUrl(response),
-          schema: Schemas.EVENT_ARRAY,
-        })
-      );
-    },
-    getStarredReposForUser: async (userId, params) => {
-      return this.call(`users/${userId}/starred`, params).then(response => ({
-        response,
-        nextPageUrl: this.getNextPageUrl(response),
+    getEventsReceived: (
+      userId: string,
+      params: SpecialParameters = {}
+    ): CallParameters =>
+      this.list({
+        endpoint: `users/${userId}/received_events`,
+        params: params || {},
+        schema: Schemas.EVENT_ARRAY,
+        paginationArgs: [userId],
+      }),
+
+    getStarredReposForUser: (userId: string, params: SpecialParameters = {}) =>
+      this.list({
+        endpoint: `users/${userId}/starred`,
+        params,
         schema: Schemas.REPO_ARRAY,
-      }));
-    },
+        paginationArgs: [userId],
+      }),
   };
   search = {
-    repos: async (q, params) => {
-      return this.call(`search/repositories?q=${q}`, params).then(response => ({
-        response,
-        nextPageUrl: this.getNextPageUrl(response),
+    repos: (q: string, params: SpecialParameters = {}) =>
+      this.list({
+        endpoint: `search/repositories?q=${q}`,
+        params,
         schema: Schemas.REPO_ARRAY,
+        paginationArgs: [q],
         normalizrKey: 'items',
-      }));
-    },
-    users: async (q, params) => {
-      return this.call(`search/users?q=${q}`, params).then(response => ({
-        response,
-        nextPageUrl: this.getNextPageUrl(response),
+      }),
+
+    users: (q: string, params: SpecialParameters = {}) =>
+      this.list({
+        endpoint: `search/users?q=${q}`,
+        params,
         schema: Schemas.USER_ARRAY,
+        paginationArgs: [q],
         normalizrKey: 'items',
-      }));
-    },
+      }),
   };
   orgs = {
-    getById: async (orgId, params) => {
-      return this.call(`orgs/${orgId}`, params).then(response => ({
-        response,
+    /**
+     * Get org by id
+     */
+    getById: (orgId: string, params: SpecialParameters = {}) =>
+      this.get({
+        endpoint: `orgs/${orgId}`,
+        params,
         schema: Schemas.ORG,
-      }));
-    },
-    getMembers: async (orgId, params) => {
-      return this.call(`orgs/${orgId}/members`, params).then(response => ({
-        response,
-        nextPageUrl: this.getNextPageUrl(response),
+      }),
+    getMembers: (orgId: string, params: SpecialParameters = {}) =>
+      this.list({
+        endpoint: `orgs/${orgId}/members`,
+        params,
         schema: Schemas.USER_ARRAY,
-
-      }));
-    },
+        paginationArgs: [orgId],
+      }),
   };
 }

--- a/src/api/reducers/pagination.js
+++ b/src/api/reducers/pagination.js
@@ -6,8 +6,8 @@ import * as Actions from '../actions';
 // Creates a reducer managing pagination, given the action types to handle,
 // and a function telling how to extract the key from an action.
 const paginate = types => {
-  if (typeof types !== 'object' || Object.keys(types).length !== 4) {
-    throw new Error('Expected types to be an object of 4 props.');
+  if (typeof types !== 'object' || Object.keys(types).length !== 5) {
+    throw new Error('Expected types to be an object of 5 props.');
   }
 
   const updatePagination = (

--- a/src/utils/action-helper.js
+++ b/src/utils/action-helper.js
@@ -2,11 +2,10 @@ export const createActionSet = actionName => ({
   PENDING: `${actionName}_PENDING`,
   SUCCESS: `${actionName}_SUCCESS`,
   ERROR: `${actionName}_ERROR`,
+  actionName,
 });
 
 export const createPaginationActionSet = actionName => ({
-  PENDING: `${actionName}_PENDING`,
-  SUCCESS: `${actionName}_SUCCESS`,
-  ERROR: `${actionName}_ERROR`,
+  ...createActionSet(actionName),
   RESET: `${actionName}_RESET`,
 });

--- a/src/utils/api-helpers.js
+++ b/src/utils/api-helpers.js
@@ -1,6 +1,6 @@
 import { Alert } from 'react-native';
 
-export const getActionKeyFromArgs = args => args.join('-');
+export const getPaginationKey = args => args.join('-');
 
 export const actionNameForCall = (namespace, method, prefix = '') => {
   const upperCased = `${namespace}_${method}`
@@ -10,17 +10,9 @@ export const actionNameForCall = (namespace, method, prefix = '') => {
   return `${prefix}${upperCased}`;
 };
 
-export const splitArgs = (fn, args) => {
-  const declaredArgsCount = fn.length;
-  const isExtraArgAvailable = args.length === declaredArgsCount;
-
-  return {
-    pureArgs: isExtraArgAvailable ? args.slice(0, -1) : args,
-    extraArg: isExtraArgAvailable ? args[args.length - 1] : {},
-  };
-};
-
 // TODO: used mainly for developping this PR, but may come handy for #430
 export const displayError = error => {
   Alert.alert('API Error', error);
+
+  return Promise.reject(error);
 };


### PR DESCRIPTION
## Description

As mentioned in #770, this is the smallest subset of changes required for the Proxy<=>Client refactoring.

* Client methods don't trigger the `fetch()` anymore, but instead hands out all call parameters to the Proxy
* only `list` and `get` operations are supported
* Got rid of the weird & confusing `splitArgs()` things.
* Our actions sets now contain the action "name"

Tested all the screens migrated to the new API so far, every one of them still work without changing a single char.

<!-- DO NOT MODIFY BELOW THIS LINE -->
<!-- ----------------------------- -->
<!-- GITPOINT_PR -->
