### PR TITLE
refactor(repository-screen): switch to GraphQL

### DIFF
--- a/__tests__/tests/components/RepositoryProfile.js
+++ b/__tests__/tests/components/RepositoryProfile.js
@@ -6,24 +6,25 @@ import { RepositoryProfile } from 'components';
 
 const defaultProps = {
   repository: {
-    fork: true,
+    isFork: true,
     parent: true,
-    language: 'en',
+    primaryLanguage: {
+      name: 'JavaScript',
+      color: '#FFCC00',
+    },
+    isStarred: false,
+    isSubscribed: false,
   },
-  starred: false,
   navigation: {
     navigate() {},
   },
   loading: false,
-  subscribed: false,
   locale: 'en',
 };
 
 describe('<RepositoryProfile />', () => {
   it('should render the Icon component if loading is false and repository language is not null', () => {
-    const wrapper = shallow(
-      <RepositoryProfile {...defaultProps} language={false} />
-    );
+    const wrapper = shallow(<RepositoryProfile {...defaultProps} />);
     const icon = wrapper.find({ name: 'fiber-manual-record' });
 
     expect(icon.length).toBeTruthy();
@@ -44,7 +45,7 @@ describe('<RepositoryProfile />', () => {
         {...defaultProps}
         repository={{
           ...defaultProps.repository,
-          language: null,
+          primaryLanguage: null,
         }}
       />
     );
@@ -53,7 +54,7 @@ describe('<RepositoryProfile />', () => {
     expect(icon.length).toBeFalsy();
   });
 
-  it('should render repository fork text container if repository.fork is true', () => {
+  it('should render repository fork text container if repository.isFork is true', () => {
     const wrapper = shallow(<RepositoryProfile {...defaultProps} />);
     const repositoryContainer = wrapper.find({
       nativeId: 'repository-fork-container',

--- a/__tests__/tests/components/RepositoryProfile.js
+++ b/__tests__/tests/components/RepositoryProfile.js
@@ -7,13 +7,15 @@ import { RepositoryProfile } from 'components';
 const defaultProps = {
   repository: {
     isFork: true,
-    parent: true,
+    parent: {
+      nameWithOwner: 'foo/bar',
+    },
     primaryLanguage: {
       name: 'JavaScript',
       color: '#FFCC00',
     },
-    isStarred: false,
-    isSubscribed: false,
+    viewerHasStarred: false,
+    viewerSubscription: 'UNSUBSCRIBED',
   },
   navigation: {
     navigate() {},
@@ -78,7 +80,7 @@ describe('<RepositoryProfile />', () => {
       .simulate('press');
 
     expect(navigateMock).toHaveBeenCalledWith('Repository', {
-      repository: true,
+      repoId: 'foo/bar',
     });
   });
 });

--- a/src/api/actions/index.js
+++ b/src/api/actions/index.js
@@ -6,6 +6,10 @@ export const ACTIVITY_GET_EVENTS_RECEIVED = createPaginationActionSet(
 export const ACTIVITY_GET_STARRED_REPOS_FOR_USER = createPaginationActionSet(
   'ACTIVITY_GET_STARRED_REPOS_FOR_USER'
 );
+export const ACTIVITY_STAR_REPO = createActionSet('ACTIVITY_STAR_REPO');
+export const ACTIVITY_UNSTAR_REPO = createActionSet('ACTIVITY_UNSTAR_REPO');
+export const ACTIVITY_WATCH_REPO = createActionSet('ACTIVITY_WATCH_REPO');
+export const ACTIVITY_UNWATCH_REPO = createActionSet('ACTIVITY_UNWATCH_REPO');
 export const SEARCH_REPOS = createPaginationActionSet('SEARCH_REPOS');
 export const SEARCH_USERS = createPaginationActionSet('SEARCH_USERS');
 export const ORGS_GET_MEMBERS = createPaginationActionSet('ORGS_GET_MEMBERS');
@@ -16,3 +20,4 @@ export const GRAPHQL_GET_REPO = createActionSet('GRAPHQL_GET_REPO');
 export const REPOS_GET_CONTRIBUTORS = createPaginationActionSet(
   'REPOS_GET_CONTRIBUTORS'
 );
+export const REPOS_FORK = createActionSet('REPOS_FORK');

--- a/src/api/actions/index.js
+++ b/src/api/actions/index.js
@@ -10,3 +10,9 @@ export const SEARCH_REPOS = createPaginationActionSet('SEARCH_REPOS');
 export const SEARCH_USERS = createPaginationActionSet('SEARCH_USERS');
 export const ORGS_GET_MEMBERS = createPaginationActionSet('ORGS_GET_MEMBERS');
 export const ORGS_GET_BY_ID = createActionSet('ORGS_GET_BY_ID');
+
+export const GRAPHQL_GET_REPO = createActionSet('GRAPHQL_GET_REPO');
+
+export const REPOS_GET_CONTRIBUTORS = createPaginationActionSet(
+  'REPOS_GET_CONTRIBUTORS'
+);

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -287,8 +287,11 @@ export class Client {
           type: 'gqlRepos',
           id: repoId,
           updater: gqlRepo => ({
-            isStarred: true,
-            stargazersCount: gqlRepo.stargazersCount + 1,
+            viewerHasStarred: true,
+            stargazers: {
+              ...gqlRepo.stargazers,
+              totalCount: gqlRepo.stargazers.totalCount + 1,
+            },
           }),
         },
       }),
@@ -301,8 +304,11 @@ export class Client {
           type: 'gqlRepos',
           id: repoId,
           updater: gqlRepo => ({
-            isStarred: false,
-            stargazersCount: gqlRepo.stargazersCount - 1,
+            viewerHasStarred: false,
+            stargazers: {
+              ...gqlRepo.stargazers,
+              totalCount: gqlRepo.stargazers.totalCount - 1,
+            },
           }),
         },
       }),
@@ -320,8 +326,11 @@ export class Client {
           type: 'gqlRepos',
           id: repoId,
           updater: gqlRepo => ({
-            isSubscribed: true,
-            watchersCount: gqlRepo.watchersCount + 1,
+            viewerSubscription: 'SUBSCRIBED',
+            watchers: {
+              ...gqlRepo.watchers,
+              totalCount: gqlRepo.watchers.totalCount + 1,
+            },
           }),
         },
       }),
@@ -334,8 +343,11 @@ export class Client {
           type: 'gqlRepos',
           id: repoId,
           updater: gqlRepo => ({
-            isSubscribed: false,
-            watchersCount: gqlRepo.watchersCount - 1,
+            viewerSubscription: 'UNSUBSCRIBED',
+            watchers: {
+              ...gqlRepo.watchers,
+              totalCount: gqlRepo.watchers.totalCount - 1,
+            },
           }),
         },
       }),

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -308,8 +308,6 @@ export const fetchForkRepo = (owner, repo, accessToken) =>
 export const fetchStarCount = (owner, accessToken) =>
   v3.count(`/users/${owner}/starred`, accessToken);
 
-export const isWatchingRepo = (url, accessToken) => v3.head(url, accessToken);
-
 export const watchRepo = (owner, repo, accessToken) =>
   v3.put(`/repos/${owner}/${repo}/subscription`, accessToken, {
     subscribed: true,
@@ -382,15 +380,6 @@ export const fetchNotificationsCount = accessToken =>
 
 export const fetchRepoNotificationsCount = (owner, repoName, accessToken) =>
   v3.count(`/repos/${owner}/${repoName}/notifications?per_page=1`, accessToken);
-
-export const fetchRepoTopics = async (owner, repoName, accessToken) => {
-  const response = await v3.call(
-    `/repos/${owner}/${repoName}/topics`,
-    v3.parameters(accessToken, METHOD.GET, ACCEPT.MERCY_PREVIEW)
-  );
-
-  return response.json();
-};
 
 export const fetchIssueEvents = (
   owner: string,

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -299,22 +299,8 @@ export const fetchMarkRepoNotificationAsRead = (repoFullName, accessToken) =>
 export const fetchMarkAllNotificationsAsRead = accessToken =>
   v3.put('/notifications', accessToken);
 
-export const fetchChangeStarStatusRepo = (owner, repo, starred, accessToken) =>
-  v3[starred ? 'delete' : 'put'](`/user/starred/${owner}/${repo}`, accessToken);
-
-export const fetchForkRepo = (owner, repo, accessToken) =>
-  v3.post(`/repos/${owner}/${repo}/forks`, accessToken);
-
 export const fetchStarCount = (owner, accessToken) =>
   v3.count(`/users/${owner}/starred`, accessToken);
-
-export const watchRepo = (owner, repo, accessToken) =>
-  v3.put(`/repos/${owner}/${repo}/subscription`, accessToken, {
-    subscribed: true,
-  });
-
-export const unWatchRepo = (owner, repo, accessToken) =>
-  v3.delete(`/repos/${owner}/${repo}/subscription`, accessToken);
 
 export const fetchChangeFollowStatus = (user, isFollowing, accessToken) =>
   v3[isFollowing ? 'delete' : 'put'](`/user/following/${user}`, accessToken);

--- a/src/api/proxies/create-dispatch-proxy.js
+++ b/src/api/proxies/create-dispatch-proxy.js
@@ -103,14 +103,76 @@ export const createDispatchProxy = (Provider: Client) => {
                 });
               }
 
-              // 9. Parse the JSON from the answer
+              // 9. Did we just delete something?
+              if (callType.type === 'delete') {
+                if (action.pagination) {
+                  // Was it a pagination item? If so, remove its id
+                  // from its related pagination
+                  dispatch({
+                    pagination: {
+                      name: action.pagination.actionName,
+                      id: paginationKey,
+                      entityId: callType.entityId,
+                    },
+                    id: paginationKey,
+                    type: action.pagination.REMOVE,
+                  });
+                  // bail since we don't need to parse the JSON
+                  dispatch({
+                    id: paginationKey,
+                    type: action.SUCCESS,
+                  });
+                } else if (callType.updateEntity) {
+                  const { type, id, updater } = callType.updateEntity;
+
+                  const entity = getState().entities[type][id];
+
+                  dispatch({
+                    type: action.SUCCESS,
+                    entities: {
+                      [type]: {
+                        [id]: updater(entity),
+                      },
+                    },
+                  });
+                }
+
+                return Promise.resolve();
+              }
+
+              // 9-1. Or did we change a status? no JSON
+              if (callType.type === 'put') {
+                if (callType.updateEntity) {
+                  const { type, id, updater } = callType.updateEntity;
+
+                  const entity = getState().entities[type][id];
+
+                  dispatch({
+                    type: action.SUCCESS,
+                    entities: {
+                      [type]: {
+                        [id]: updater(entity),
+                      },
+                    },
+                  });
+                } else {
+                  dispatch({
+                    id: paginationKey,
+                    type: action.SUCCESS,
+                  });
+                }
+
+                return Promise.resolve();
+              }
+
+              // 10. Parse the JSON from the answer
               return response.json().then(json => {
                 const normalizedJson = normalize(
                   callType.normalizrKey ? json[callType.normalizrKey] : json,
                   callType.schema
                 );
 
-                // 10. Did we get a next page of results for a pagination?
+                // 11. Did we get a next page of results for a pagination?
                 // If so, prepare the structure that will be merged in the existing
                 // pagination state.
                 if (callType.type === 'list') {
@@ -124,7 +186,7 @@ export const createDispatchProxy = (Provider: Client) => {
                   delete normalizedJson.result;
                 }
 
-                // 11. All done, dispatch success.
+                // 12. All done, dispatch success.
                 dispatch({
                   ...normalizedJson,
                   id: paginationKey,

--- a/src/api/proxies/create-dispatch-proxy.js
+++ b/src/api/proxies/create-dispatch-proxy.js
@@ -167,6 +167,12 @@ export const createDispatchProxy = (Provider: Client) => {
 
               // 10. Parse the JSON from the answer
               return response.json().then(json => {
+                if (callType.type === 'query') {
+                  if (json.errors && json.errors.length) {
+                    return Promise.reject(json.errors[0].message);
+                  }
+                }
+
                 const normalizedJson = normalize(
                   callType.normalizrKey ? json[callType.normalizrKey] : json,
                   callType.schema

--- a/src/api/proxies/create-dispatch-proxy.js
+++ b/src/api/proxies/create-dispatch-proxy.js
@@ -171,6 +171,8 @@ export const createDispatchProxy = (Provider: Client) => {
                   if (json.errors && json.errors.length) {
                     return Promise.reject(json.errors[0].message);
                   }
+
+                  callType.normalizrKey = 'data';
                 }
 
                 const normalizedJson = normalize(

--- a/src/api/queries/index.js
+++ b/src/api/queries/index.js
@@ -1,0 +1,1 @@
+export * from './repo.query';

--- a/src/api/queries/repo.query.js
+++ b/src/api/queries/repo.query.js
@@ -36,10 +36,10 @@ query ($owner: String!, $name: String!) {
   repository(owner: $owner, name: $name) {
     url
     name
-    nameWithOwner
+    fullName: nameWithOwner
     isFork
     parent {
-      nameWithOwner
+      fullName: nameWithOwner
       url
     }
     defaultBranchRef {

--- a/src/api/queries/repo.query.js
+++ b/src/api/queries/repo.query.js
@@ -1,0 +1,122 @@
+export const repoQuery = `fragment IssuesList on IssueEdge {
+  node {
+    state
+    title
+    number
+    createdAt
+    closedAt
+    resourcePath
+    author {
+      login
+    }
+    comments {
+      totalCount
+    }
+  }
+}
+
+fragment PullRequestsList on PullRequestEdge {
+  node {
+    state
+    title
+    number
+    createdAt
+    closedAt
+    resourcePath
+    author {
+      login
+    }
+    comments {
+      totalCount
+    }
+  }
+}
+
+query ($owner: String!, $name: String!) {
+  repository(owner: $owner, name: $name) {
+    name
+    nameWithOwner
+    resourcePath
+    isFork
+    parent {
+      nameWithOwner
+      url
+    }
+    defaultBranchRef {
+      name
+    }
+    primaryLanguage {
+      name
+      color
+    }
+    languages(first: 20, orderBy: {field: SIZE, direction: DESC}) {
+      edges {
+        node {
+          name
+          color
+        }
+      }
+    }
+    README: object(expression: "HEAD:README.md") {
+      ... on Blob {
+        id
+      }
+    }
+    stargazers {
+      totalCount
+    }
+    viewerHasStarred
+    watchers(first: 10) {
+      totalCount
+    }
+    viewerSubscription
+    forkCount
+    description
+    repositoryTopics(first: 10) {
+      edges {
+        node {
+          topic {
+            name
+          }
+        }
+      }
+    }
+    openIssues: issues(first: 3, states: OPEN, orderBy: {field: CREATED_AT, direction: DESC}) {
+      totalCount
+      edges {
+        ...IssuesList
+      }
+    }
+    openPullRequests: pullRequests(first: 3, states: OPEN, orderBy: {field: CREATED_AT, direction: DESC}) {
+      totalCount
+      edges {
+        ...PullRequestsList
+      }
+    }
+    hasIssuesEnabled
+    pullRequestsCount: pullRequests {
+      totalCount
+    }
+    issuesCount: issues {
+      totalCount
+    }
+    owner {
+      login
+      avatarUrl
+    }
+    issues: issues(first: 50, orderBy: {field: CREATED_AT, direction: DESC}) {
+      totalCount
+      edges {
+        ...IssuesList
+      }
+    }
+    pullRequests: pullRequests(first: 50, orderBy: {field: CREATED_AT, direction: DESC}) {
+      totalCount
+      edges {
+        ...PullRequestsList
+      }
+    }
+  }
+}
+
+`;

--- a/src/api/queries/repo.query.js
+++ b/src/api/queries/repo.query.js
@@ -1,34 +1,28 @@
-export const repoQuery = `fragment IssuesList on IssueEdge {
-  node {
-    state
-    title
-    number
-    createdAt
-    closedAt
-    resourcePath
-    author {
-      login
-    }
-    comments {
-      totalCount
-    }
+export const repoQuery = `fragment IssuesList on Issue {
+  state
+  title
+  number
+  createdAt
+  closedAt
+  author {
+    login
+  }
+  comments {
+    totalCount
   }
 }
 
-fragment PullRequestsList on PullRequestEdge {
-  node {
-    state
-    title
-    number
-    createdAt
-    closedAt
-    resourcePath
-    author {
-      login
-    }
-    comments {
-      totalCount
-    }
+fragment PullRequestsList on PullRequest {
+  state
+  title
+  number
+  createdAt
+  closedAt
+  author {
+    login
+  }
+  comments {
+    totalCount
   }
 }
 
@@ -36,10 +30,10 @@ query ($owner: String!, $name: String!) {
   repository(owner: $owner, name: $name) {
     url
     name
-    fullName: nameWithOwner
+     nameWithOwner
     isFork
     parent {
-      fullName: nameWithOwner
+       nameWithOwner
       url
     }
     defaultBranchRef {
@@ -50,11 +44,10 @@ query ($owner: String!, $name: String!) {
       color
     }
     languages(first: 20, orderBy: {field: SIZE, direction: DESC}) {
-      edges {
-        node {
-          name
-          color
-        }
+      totalCount
+      nodes {
+        name
+        color
       }
     }
     README: object(expression: "HEAD:README.md") {
@@ -66,30 +59,29 @@ query ($owner: String!, $name: String!) {
       totalCount
     }
     viewerHasStarred
-    watchers(first: 10) {
+    watchers(first: 1) {
       totalCount
     }
     viewerSubscription
     forkCount
     description
     repositoryTopics(first: 10) {
-      edges {
-        node {
-          topic {
-            name
-          }
+      totalCount
+      nodes {
+        topic {
+          name
         }
       }
     }
-    openIssues: issues(first: 3, states: OPEN, orderBy: {field: CREATED_AT, direction: DESC}) {
+    openIssuesPreview: issues(first: 3, states: OPEN, orderBy: {field: CREATED_AT, direction: DESC}) {
       totalCount
-      edges {
+      nodes {
         ...IssuesList
       }
     }
-    openPullRequests: pullRequests(first: 3, states: OPEN, orderBy: {field: CREATED_AT, direction: DESC}) {
+    openPullRequestsPreview: pullRequests(first: 3, states: OPEN, orderBy: {field: CREATED_AT, direction: DESC}) {
       totalCount
-      edges {
+      nodes {
         ...PullRequestsList
       }
     }
@@ -106,13 +98,13 @@ query ($owner: String!, $name: String!) {
     }
     issues: issues(first: 50, orderBy: {field: CREATED_AT, direction: DESC}) {
       totalCount
-      edges {
+      nodes {
         ...IssuesList
       }
     }
     pullRequests: pullRequests(first: 50, orderBy: {field: CREATED_AT, direction: DESC}) {
       totalCount
-      edges {
+      nodes {
         ...PullRequestsList
       }
     }

--- a/src/api/queries/repo.query.js
+++ b/src/api/queries/repo.query.js
@@ -34,9 +34,9 @@ fragment PullRequestsList on PullRequestEdge {
 
 query ($owner: String!, $name: String!) {
   repository(owner: $owner, name: $name) {
+    url
     name
     nameWithOwner
-    resourcePath
     isFork
     parent {
       nameWithOwner

--- a/src/api/reducers/entities.js
+++ b/src/api/reducers/entities.js
@@ -7,6 +7,7 @@ export const entities = (
     orgs: {},
     repos: {},
     users: {},
+    gqlRepos: {},
   },
   action
 ) => {

--- a/src/api/reducers/pagination.js
+++ b/src/api/reducers/pagination.js
@@ -84,4 +84,5 @@ export const pagination = combineReducers({
   SEARCH_REPOS: paginate(Actions.SEARCH_REPOS),
   SEARCH_USERS: paginate(Actions.SEARCH_USERS),
   ORGS_GET_MEMBERS: paginate(Actions.ORGS_GET_MEMBERS),
+  REPOS_GET_CONTRIBUTORS: paginate(Actions.REPOS_GET_CONTRIBUTORS),
 });

--- a/src/api/schemas/gql-repos.js
+++ b/src/api/schemas/gql-repos.js
@@ -33,8 +33,8 @@ export const gqlRepoSchema = new schema.Entity(
         hasReadme: repository.README !== null,
         stargazersCount: repository.stargazers.totalCount,
         watchersCount: repository.watchers.totalCount,
-        subscription: repository.viewerSubscription,
         isStarred: repository.viewerHasStarred,
+        isSubscribed: repository.viewerSubscription === 'SUBSCRIBED',
         description: repository.description,
         parent: repository.parent
           ? {

--- a/src/api/schemas/gql-repos.js
+++ b/src/api/schemas/gql-repos.js
@@ -20,12 +20,12 @@ export const gqlRepoSchema = new schema.Entity(
   {},
   {
     idAttribute: ({ data: { repository } }) => {
-      return repository.nameWithOwner.toLowerCase();
+      return repository.fullName.toLowerCase();
     },
     processStrategy: ({ data: { repository } }) => {
       return {
         name: repository.name,
-        fullName: repository.nameWithOwner,
+        fullName: repository.fullName,
         isFork: repository.isFork,
         forkedFrom: repository.parent ? repository.parent.nameWithOwner : null,
         forkCount: repository.forkCount,
@@ -39,10 +39,8 @@ export const gqlRepoSchema = new schema.Entity(
         html_url: repository.url,
         parent: repository.parent
           ? {
-              full_name: repository.parent.nameWithOwner,
-              url: `https://api.github.com/repos/${
-                repository.parent.nameWithOwner
-              }`,
+              fullName: repository.parent.fullName,
+              url: `https://api.github.com/repos/${repository.parent.fullName}`,
             }
           : null,
         primaryLanguage: repository.primaryLanguage,
@@ -58,20 +56,20 @@ export const gqlRepoSchema = new schema.Entity(
         hasIssuesEnabled: repository.hasIssuesEnabled,
         openIssuesPreview: formatIssues(
           repository.openIssues,
-          repository.nameWithOwner
+          repository.fullName
         ),
         openPullRequestsPreview: formatIssues(
           repository.openPullRequests,
-          repository.nameWithOwner,
+          repository.fullName,
           true
         ),
-        issues: formatIssues(repository.issues, repository.nameWithOwner),
+        issues: formatIssues(repository.issues, repository.fullName),
         pullRequests: formatIssues(
           repository.pullRequests,
-          repository.nameWithOwner
+          repository.fullName
         ),
         contents_url: `https://api.github.com/repos/${
-          repository.nameWithOwner
+          repository.fullName
         }/contents`,
       };
     },

--- a/src/api/schemas/gql-repos.js
+++ b/src/api/schemas/gql-repos.js
@@ -36,11 +36,13 @@ export const gqlRepoSchema = new schema.Entity(
         isStarred: repository.viewerHasStarred,
         isSubscribed: repository.viewerSubscription === 'SUBSCRIBED',
         description: repository.description,
+        html_url: repository.url,
         parent: repository.parent
           ? {
               full_name: repository.parent.nameWithOwner,
-              url: `https://api.github.com/repos/
-                ${repository.parent.nameWithOwner}`,
+              url: `https://api.github.com/repos/${
+                repository.parent.nameWithOwner
+              }`,
             }
           : null,
         primaryLanguage: repository.primaryLanguage,

--- a/src/api/schemas/gql-repos.js
+++ b/src/api/schemas/gql-repos.js
@@ -1,0 +1,77 @@
+import { schema } from 'normalizr';
+
+const formatIssues = (list, repoId, isPR = false) => {
+  if (!list.edges) return [];
+
+  return list.edges.map(({ node }) => ({
+    ...node,
+    state: node.state.toLowerCase(),
+    comments: node.comments.totalCount,
+    created_at: node.createdAt,
+    closed_at: node.closedAt,
+    pull_request: isPR,
+    user: node.author,
+    url: `https://api.github.com/repos/${repoId}/issues/${node.number}`,
+  }));
+};
+
+export const gqlRepoSchema = new schema.Entity(
+  'gqlRepos',
+  {},
+  {
+    idAttribute: ({ data: { repository } }) => {
+      return repository.nameWithOwner.toLowerCase();
+    },
+    processStrategy: ({ data: { repository } }) => {
+      return {
+        name: repository.name,
+        fullName: repository.nameWithOwner,
+        isFork: repository.isFork,
+        forkedFrom: repository.parent ? repository.parent.nameWithOwner : null,
+        forkCount: repository.forkCount,
+        defaultBranchName: repository.defaultBranchRef.name,
+        hasReadme: repository.README !== null,
+        stargazersCount: repository.stargazers.totalCount,
+        watchersCount: repository.watchers.totalCount,
+        subscription: repository.viewerSubscription,
+        isStarred: repository.viewerHasStarred,
+        description: repository.description,
+        parent: repository.parent
+          ? {
+              full_name: repository.parent.nameWithOwner,
+              url: `https://api.github.com/repos/
+                ${repository.parent.nameWithOwner}`,
+            }
+          : null,
+        primaryLanguage: repository.primaryLanguage,
+        issuesCount: repository.issuesCount.totalCount,
+        pullRequestsCount: repository.pullRequestsCount.totalCount,
+        owner: {
+          login: repository.owner.login,
+          avatar_url: repository.owner.avatarUrl,
+        },
+        topics: repository.repositoryTopics.edges
+          ? repository.repositoryTopics.edges.map(item => item.node.topic.name)
+          : [],
+        hasIssuesEnabled: repository.hasIssuesEnabled,
+        openIssuesPreview: formatIssues(
+          repository.openIssues,
+          repository.nameWithOwner
+        ),
+        openPullRequestsPreview: formatIssues(
+          repository.openPullRequests,
+          repository.nameWithOwner,
+          true
+        ),
+        issues: formatIssues(repository.issues, repository.nameWithOwner),
+        pullRequests: formatIssues(
+          repository.pullRequests,
+          repository.nameWithOwner
+        ),
+        contents_url: `https://api.github.com/repos/${
+          repository.nameWithOwner
+        }/contents`,
+      };
+    },
+  }
+);

--- a/src/api/schemas/gql-repos.js
+++ b/src/api/schemas/gql-repos.js
@@ -1,77 +1,12 @@
 import { schema } from 'normalizr';
 
-const formatIssues = (list, repoId, isPR = false) => {
-  if (!list.edges) return [];
-
-  return list.edges.map(({ node }) => ({
-    ...node,
-    state: node.state.toLowerCase(),
-    comments: node.comments.totalCount,
-    created_at: node.createdAt,
-    closed_at: node.closedAt,
-    pull_request: isPR,
-    user: node.author,
-    url: `https://api.github.com/repos/${repoId}/issues/${node.number}`,
-  }));
-};
-
 export const gqlRepoSchema = new schema.Entity(
   'gqlRepos',
   {},
   {
-    idAttribute: ({ data: { repository } }) => {
-      return repository.fullName.toLowerCase();
+    idAttribute: ({ repository }) => {
+      return repository.nameWithOwner.toLowerCase();
     },
-    processStrategy: ({ data: { repository } }) => {
-      return {
-        name: repository.name,
-        fullName: repository.fullName,
-        isFork: repository.isFork,
-        forkedFrom: repository.parent ? repository.parent.nameWithOwner : null,
-        forkCount: repository.forkCount,
-        defaultBranchName: repository.defaultBranchRef.name,
-        hasReadme: repository.README !== null,
-        stargazersCount: repository.stargazers.totalCount,
-        watchersCount: repository.watchers.totalCount,
-        isStarred: repository.viewerHasStarred,
-        isSubscribed: repository.viewerSubscription === 'SUBSCRIBED',
-        description: repository.description,
-        html_url: repository.url,
-        parent: repository.parent
-          ? {
-              fullName: repository.parent.fullName,
-              url: `https://api.github.com/repos/${repository.parent.fullName}`,
-            }
-          : null,
-        primaryLanguage: repository.primaryLanguage,
-        issuesCount: repository.issuesCount.totalCount,
-        pullRequestsCount: repository.pullRequestsCount.totalCount,
-        owner: {
-          login: repository.owner.login,
-          avatar_url: repository.owner.avatarUrl,
-        },
-        topics: repository.repositoryTopics.edges
-          ? repository.repositoryTopics.edges.map(item => item.node.topic.name)
-          : [],
-        hasIssuesEnabled: repository.hasIssuesEnabled,
-        openIssuesPreview: formatIssues(
-          repository.openIssues,
-          repository.fullName
-        ),
-        openPullRequestsPreview: formatIssues(
-          repository.openPullRequests,
-          repository.fullName,
-          true
-        ),
-        issues: formatIssues(repository.issues, repository.fullName),
-        pullRequests: formatIssues(
-          repository.pullRequests,
-          repository.fullName
-        ),
-        contents_url: `https://api.github.com/repos/${
-          repository.fullName
-        }/contents`,
-      };
-    },
+    processStrategy: ({ repository }) => repository,
   }
 );

--- a/src/api/schemas/gql-repos.js
+++ b/src/api/schemas/gql-repos.js
@@ -7,6 +7,9 @@ export const gqlRepoSchema = new schema.Entity(
     idAttribute: ({ repository }) => {
       return repository.nameWithOwner.toLowerCase();
     },
-    processStrategy: ({ repository }) => repository,
+    processStrategy: ({ repository }) => ({
+      ...repository,
+      webUrl: `https://github.com/${repository.nameWithOwner}`,
+    }),
   }
 );

--- a/src/api/schemas/index.js
+++ b/src/api/schemas/index.js
@@ -2,6 +2,7 @@ import { eventSchema } from './events';
 import { repoSchema } from './repos';
 import { orgSchema } from './orgs';
 import { userSchema } from './users';
+import { gqlRepoSchema } from './gql-repos';
 
 export default {
   EVENT: eventSchema,
@@ -12,4 +13,5 @@ export default {
   USER_ARRAY: [userSchema],
   ORG: orgSchema,
   ORG_ARRAY: [orgSchema],
+  GQL_REPO: gqlRepoSchema,
 };

--- a/src/components/issue-list-item.component.js
+++ b/src/components/issue-list-item.component.js
@@ -68,7 +68,8 @@ export const IssueListItem = ({ type, issue, navigation, locale }: Props) => (
         issue,
         isPR: !!issue.pull_request,
         locale,
-      })}
+      })
+    }
     underlayColor={colors.greyLight}
   >
     <View style={styles.container}>

--- a/src/components/repository-profile.component.js
+++ b/src/components/repository-profile.component.js
@@ -231,7 +231,7 @@ export const RepositoryProfile = ({
         <Text style={styles.unitText}>
           {translate('repository.main.watchers', locale)}
         </Text>
-        {repository.subscription === 'SUBSCRIBED' && (
+        {repository.isSubscribed && (
           <View style={styles.badgeView}>
             <Text style={[styles.unitStatus, styles.badge]}>
               {translate('repository.main.watching', locale)}

--- a/src/components/repository-profile.component.js
+++ b/src/components/repository-profile.component.js
@@ -172,8 +172,7 @@ export const RepositoryProfile = ({
       />
 
       <Text style={styles.title}>
-        {repository.primaryLanguage ||
-          translate('repository.main.notFoundRepo', locale)}
+        {repository.name || translate('repository.main.notFoundRepo', locale)}
       </Text>
 
       {!hasError && (
@@ -205,12 +204,12 @@ export const RepositoryProfile = ({
                 style={{ ...fonts.fontPrimaryBold }}
                 onPress={() =>
                   navigation.navigate('Repository', {
-                    repository: repository.parent,
+                    repoId: repository.parent.nameWithOwner,
                   })
                 }
               >
                 {' '}
-                {repository.parent.fullName}
+                {repository.parent.nameWithOwner}
               </Text>
             </Text>
           )}
@@ -226,8 +225,10 @@ export const RepositoryProfile = ({
               {emojifyText(':hourglass:')}
             </Text>
           )}
-          {!isChangingStar && !isNaN(parseInt(repository.stargazersCount, 10))
-            ? abbreviateNumber(repository.stargazersCount)
+          {!isChangingStar &&
+          repository.stargazers &&
+          !isNaN(parseInt(repository.stargazers.totalCount, 10))
+            ? abbreviateNumber(repository.stargazers.totalCount)
             : ' '}
         </Text>
         {!hasError && (
@@ -235,7 +236,7 @@ export const RepositoryProfile = ({
             {translate('repository.main.starsTitle', locale)}
           </Text>
         )}
-        {repository.isStarred && (
+        {repository.viewerHasStarred && (
           <View style={styles.badgeView}>
             <Text style={[styles.unitStatus, styles.badge]}>
               {translate('repository.main.starred', locale)}
@@ -252,8 +253,9 @@ export const RepositoryProfile = ({
             </Text>
           )}
           {!isChangingSubscription &&
-          !isNaN(parseInt(repository.watchersCount, 10))
-            ? abbreviateNumber(repository.watchersCount)
+          repository.watchers &&
+          !isNaN(parseInt(repository.watchers.totalCount, 10))
+            ? abbreviateNumber(repository.watchers.totalCount)
             : ' '}
         </Text>
         {!hasError && (
@@ -261,7 +263,7 @@ export const RepositoryProfile = ({
             {translate('repository.main.watchers', locale)}
           </Text>
         )}
-        {repository.isSubscribed && (
+        {repository.viewerSubscription === 'SUBSCRIBED' && (
           <View style={styles.badgeView}>
             <Text style={[styles.unitStatus, styles.badge]}>
               {translate('repository.main.watching', locale)}

--- a/src/components/repository-profile.component.js
+++ b/src/components/repository-profile.component.js
@@ -11,6 +11,7 @@ type Props = {
   isChangingStar: boolean,
   isChangingSubscription: boolean,
   loading: boolean,
+  hasError: boolean,
   locale: string,
 };
 
@@ -136,11 +137,13 @@ export const RepositoryProfile = ({
   isChangingSubscription,
   navigation,
   loading,
+  hasError,
   locale,
 }: Props) => (
   <View style={styles.container}>
     <View style={styles.languageInfo}>
-      {!loading &&
+      {!hasError &&
+        !loading &&
         repository.primaryLanguage !== null && (
           <Icon
             name="fiber-manual-record"
@@ -169,20 +172,23 @@ export const RepositoryProfile = ({
       />
 
       <Text style={styles.title}>
-        {repository.name || translate('repository.main.notFoundRepo', locale)}
+        {repository.primaryLanguage ||
+          translate('repository.main.notFoundRepo', locale)}
       </Text>
 
-      <Text
-        numberOfLines={repository.isFork ? 1 : 3}
-        style={[
-          styles.subtitle,
-          repository.isFork
-            ? styles.subtitleDescriptionWithFork
-            : styles.subtitleDescriptionNoFork,
-        ]}
-      >
-        {emojifyText(repository.description) || ' '}
-      </Text>
+      {!hasError && (
+        <Text
+          numberOfLines={repository.isFork ? 1 : 3}
+          style={[
+            styles.subtitle,
+            repository.isFork
+              ? styles.subtitleDescriptionWithFork
+              : styles.subtitleDescriptionNoFork,
+          ]}
+        >
+          {emojifyText(repository.description) || ' '}
+        </Text>
+      )}
 
       {repository.isFork && (
         <Text
@@ -204,7 +210,7 @@ export const RepositoryProfile = ({
                 }
               >
                 {' '}
-                {repository.parent.full_name}
+                {repository.parent.fullName}
               </Text>
             </Text>
           )}
@@ -224,9 +230,11 @@ export const RepositoryProfile = ({
             ? abbreviateNumber(repository.stargazersCount)
             : ' '}
         </Text>
-        <Text style={styles.unitText}>
-          {translate('repository.main.starsTitle', locale)}
-        </Text>
+        {!hasError && (
+          <Text style={styles.unitText}>
+            {translate('repository.main.starsTitle', locale)}
+          </Text>
+        )}
         {repository.isStarred && (
           <View style={styles.badgeView}>
             <Text style={[styles.unitStatus, styles.badge]}>
@@ -248,9 +256,11 @@ export const RepositoryProfile = ({
             ? abbreviateNumber(repository.watchersCount)
             : ' '}
         </Text>
-        <Text style={styles.unitText}>
-          {translate('repository.main.watchers', locale)}
-        </Text>
+        {!hasError && (
+          <Text style={styles.unitText}>
+            {translate('repository.main.watchers', locale)}
+          </Text>
+        )}
         {repository.isSubscribed && (
           <View style={styles.badgeView}>
             <Text style={[styles.unitStatus, styles.badge]}>
@@ -266,9 +276,11 @@ export const RepositoryProfile = ({
             ? abbreviateNumber(repository.forkCount)
             : ' '}
         </Text>
-        <Text style={styles.unitText}>
-          {translate('repository.main.forksTitle', locale)}
-        </Text>
+        {!hasError && (
+          <Text style={styles.unitText}>
+            {translate('repository.main.forksTitle', locale)}
+          </Text>
+        )}
       </View>
     </View>
   </View>

--- a/src/components/repository-profile.component.js
+++ b/src/components/repository-profile.component.js
@@ -8,6 +8,8 @@ import { colors, fonts, normalize } from 'config';
 type Props = {
   repository: Object,
   navigation: Object,
+  isChangingStar: boolean,
+  isChangingSubscription: boolean,
   loading: boolean,
   locale: string,
 };
@@ -67,12 +69,17 @@ const styles = StyleSheet.create({
     ...fonts.fontPrimaryBold,
     fontSize: normalize(16),
   },
+  unitNumberLoading: {
+    textAlign: 'center',
+    fontSize: normalize(10),
+  },
   unitText: {
     textAlign: 'center',
     color: colors.white,
     fontSize: normalize(10),
     ...fonts.fontPrimary,
   },
+
   unitStatus: {
     textAlign: 'center',
     color: colors.lighterBoldGreen,
@@ -125,6 +132,8 @@ const iconName = repository => {
 
 export const RepositoryProfile = ({
   repository,
+  isChangingStar,
+  isChangingSubscription,
   navigation,
   loading,
   locale,
@@ -206,7 +215,12 @@ export const RepositoryProfile = ({
     <View style={styles.details}>
       <View style={styles.unit}>
         <Text style={styles.unitNumber}>
-          {!isNaN(parseInt(repository.stargazersCount, 10))
+          {isChangingStar && (
+            <Text style={styles.unitNumberLoading}>
+              {emojifyText(':hourglass:')}
+            </Text>
+          )}
+          {!isChangingStar && !isNaN(parseInt(repository.stargazersCount, 10))
             ? abbreviateNumber(repository.stargazersCount)
             : ' '}
         </Text>
@@ -224,7 +238,13 @@ export const RepositoryProfile = ({
 
       <View style={styles.unit}>
         <Text style={styles.unitNumber}>
-          {!isNaN(parseInt(repository.watchersCount, 10))
+          {isChangingSubscription && (
+            <Text style={styles.unitNumberLoading}>
+              {emojifyText(':hourglass:')}
+            </Text>
+          )}
+          {!isChangingSubscription &&
+          !isNaN(parseInt(repository.watchersCount, 10))
             ? abbreviateNumber(repository.watchersCount)
             : ' '}
         </Text>

--- a/src/components/repository-profile.component.js
+++ b/src/components/repository-profile.component.js
@@ -3,14 +3,12 @@ import { StyleSheet, Text, View, Platform } from 'react-native';
 import { Icon } from 'react-native-elements';
 
 import { emojifyText, abbreviateNumber, translate } from 'utils';
-import { colors, languageColors, fonts, normalize } from 'config';
+import { colors, fonts, normalize } from 'config';
 
 type Props = {
   repository: Object,
-  starred: boolean,
   navigation: Object,
   loading: boolean,
-  subscribed: boolean,
   locale: string,
 };
 
@@ -119,7 +117,7 @@ const iconName = repository => {
   if (!repository.name) {
     icon = 'stop';
   } else {
-    icon = repository.fork ? 'repo-forked' : 'repo';
+    icon = repository.isFork ? 'repo-forked' : 'repo';
   }
 
   return icon;
@@ -127,26 +125,25 @@ const iconName = repository => {
 
 export const RepositoryProfile = ({
   repository,
-  starred,
   navigation,
   loading,
-  subscribed,
   locale,
 }: Props) => (
   <View style={styles.container}>
     <View style={styles.languageInfo}>
       {!loading &&
-        repository.language !== null && (
+        repository.primaryLanguage !== null && (
           <Icon
             name="fiber-manual-record"
             size={15}
-            color={languageColors[repository.language]}
+            color={repository.primaryLanguage.color}
           />
         )}
 
       <Text style={[styles.languageInfoTitle]}>
-        {repository.language ||
-          translate('repository.main.unknownLanguage', locale)}
+        {repository.primaryLanguage
+          ? repository.primaryLanguage.name
+          : translate('repository.main.unknownLanguage', locale)}
       </Text>
     </View>
 
@@ -154,7 +151,7 @@ export const RepositoryProfile = ({
       <Icon
         containerStyle={[
           styles.icon,
-          repository.fork ? { marginLeft: 17 } : { marginLeft: 13 },
+          repository.isFork ? { marginLeft: 17 } : { marginLeft: 13 },
         ]}
         name={iconName(repository)}
         type="octicon"
@@ -167,10 +164,10 @@ export const RepositoryProfile = ({
       </Text>
 
       <Text
-        numberOfLines={repository.fork ? 1 : 3}
+        numberOfLines={repository.isFork ? 1 : 3}
         style={[
           styles.subtitle,
-          repository.fork
+          repository.isFork
             ? styles.subtitleDescriptionWithFork
             : styles.subtitleDescriptionNoFork,
         ]}
@@ -178,7 +175,7 @@ export const RepositoryProfile = ({
         {emojifyText(repository.description) || ' '}
       </Text>
 
-      {repository.fork && (
+      {repository.isFork && (
         <Text
           nativeId="repository-fork-container"
           style={[styles.subtitle, styles.subtitleFork]}
@@ -209,14 +206,14 @@ export const RepositoryProfile = ({
     <View style={styles.details}>
       <View style={styles.unit}>
         <Text style={styles.unitNumber}>
-          {!isNaN(parseInt(repository.stargazers_count, 10))
-            ? abbreviateNumber(repository.stargazers_count)
+          {!isNaN(parseInt(repository.stargazersCount, 10))
+            ? abbreviateNumber(repository.stargazersCount)
             : ' '}
         </Text>
         <Text style={styles.unitText}>
           {translate('repository.main.starsTitle', locale)}
         </Text>
-        {starred && (
+        {repository.isStarred && (
           <View style={styles.badgeView}>
             <Text style={[styles.unitStatus, styles.badge]}>
               {translate('repository.main.starred', locale)}
@@ -227,14 +224,14 @@ export const RepositoryProfile = ({
 
       <View style={styles.unit}>
         <Text style={styles.unitNumber}>
-          {!isNaN(parseInt(repository.subscribers_count, 10))
-            ? abbreviateNumber(repository.subscribers_count)
+          {!isNaN(parseInt(repository.watchersCount, 10))
+            ? abbreviateNumber(repository.watchersCount)
             : ' '}
         </Text>
         <Text style={styles.unitText}>
           {translate('repository.main.watchers', locale)}
         </Text>
-        {subscribed && (
+        {repository.subscription === 'SUBSCRIBED' && (
           <View style={styles.badgeView}>
             <Text style={[styles.unitStatus, styles.badge]}>
               {translate('repository.main.watching', locale)}
@@ -245,8 +242,8 @@ export const RepositoryProfile = ({
 
       <View style={styles.unit}>
         <Text style={styles.unitNumber}>
-          {!isNaN(parseInt(repository.forks, 10))
-            ? abbreviateNumber(repository.forks)
+          {!isNaN(parseInt(repository.forkCount, 10))
+            ? abbreviateNumber(repository.forkCount)
             : ' '}
         </Text>
         <Text style={styles.unitText}>

--- a/src/repository/repository.action.js
+++ b/src/repository/repository.action.js
@@ -1,25 +1,14 @@
-import {
-  fetchReadMe,
-  fetchSearch,
-  fetchChangeStarStatusRepo,
-  fetchForkRepo,
-  watchRepo,
-  unWatchRepo,
-  v3,
-} from 'api';
+import { fetchReadMe, fetchSearch, v3 } from 'api';
 import {
   GET_REPOSITORY_CONTENTS,
   GET_REPOSITORY_FILE,
   GET_REPOSITORY_ISSUES,
-  FORK_REPO_STATUS,
-  CHANGE_STAR_STATUS,
   GET_REPOSITORY_README,
   GET_REPOSITORY_LABELS,
   SEARCH_OPEN_ISSUES,
   SEARCH_CLOSED_ISSUES,
   SEARCH_OPEN_PULLS,
   SEARCH_CLOSED_PULLS,
-  GET_REPOSITORY_SUBSCRIBED_STATUS,
 } from './repository.type';
 
 export const getContents = (url, level) => {
@@ -86,99 +75,6 @@ export const getIssues = url => {
       .catch(error => {
         dispatch({
           type: GET_REPOSITORY_ISSUES.ERROR,
-          payload: error,
-        });
-      });
-  };
-};
-
-export const unSubscribeToRepo = (owner, repo) => (dispatch, getState) => {
-  const accessToken = getState().auth.accessToken;
-
-  dispatch({
-    type: GET_REPOSITORY_SUBSCRIBED_STATUS.PENDING,
-  });
-
-  return unWatchRepo(owner, repo, accessToken)
-    .then(data => data.json())
-    .then(() => {
-      dispatch({
-        type: GET_REPOSITORY_SUBSCRIBED_STATUS.SUCCESS,
-        payload: false,
-      });
-    })
-    .catch(() => {
-      dispatch({
-        type: GET_REPOSITORY_SUBSCRIBED_STATUS.ERROR,
-      });
-    });
-};
-
-export const changeStarStatusRepo = (owner, repo, starred) => {
-  return (dispatch, getState) => {
-    const accessToken = getState().auth.accessToken;
-
-    dispatch({ type: CHANGE_STAR_STATUS.PENDING });
-
-    fetchChangeStarStatusRepo(owner, repo, starred, accessToken)
-      .then(() => {
-        dispatch({
-          type: CHANGE_STAR_STATUS.SUCCESS,
-          payload: !starred,
-        });
-      })
-      .catch(error => {
-        dispatch({
-          type: CHANGE_STAR_STATUS.ERROR,
-          payload: error,
-        });
-      });
-  };
-};
-
-export const subscribeToRepo = (owner, repo) => (dispatch, getState) => {
-  const accessToken = getState().auth.accessToken;
-
-  dispatch({
-    type: GET_REPOSITORY_SUBSCRIBED_STATUS.PENDING,
-  });
-
-  return watchRepo(owner, repo, accessToken)
-    .then(data => data.json())
-    .then(result => {
-      dispatch({
-        type: GET_REPOSITORY_SUBSCRIBED_STATUS.SUCCESS,
-        payload: result.subscribed,
-      });
-    })
-    .catch(() => {
-      dispatch({
-        type: GET_REPOSITORY_SUBSCRIBED_STATUS.ERROR,
-      });
-    });
-};
-
-export const forkRepo = (owner, repo) => {
-  return (dispatch, getState) => {
-    const accessToken = getState().auth.accessToken;
-
-    dispatch({ type: FORK_REPO_STATUS.PENDING });
-
-    return fetchForkRepo(owner, repo, accessToken)
-      .then(data => {
-        return data.json();
-      })
-      .then(json => {
-        dispatch({
-          type: FORK_REPO_STATUS.SUCCESS,
-          payload: true,
-        });
-
-        return json;
-      })
-      .catch(error => {
-        dispatch({
-          type: FORK_REPO_STATUS.ERROR,
           payload: error,
         });
       });

--- a/src/repository/repository.action.js
+++ b/src/repository/repository.action.js
@@ -1,5 +1,7 @@
 import { fetchReadMe, fetchSearch, v3 } from 'api';
 import {
+  GET_REPOSITORY,
+  GET_REPOSITORY_CONTRIBUTORS,
   GET_REPOSITORY_CONTENTS,
   GET_REPOSITORY_FILE,
   GET_REPOSITORY_ISSUES,
@@ -10,6 +12,59 @@ import {
   SEARCH_OPEN_PULLS,
   SEARCH_CLOSED_PULLS,
 } from './repository.type';
+
+export const getRepository = url => {
+  return (dispatch, getState) => {
+    const accessToken = getState().auth.accessToken;
+
+    dispatch({ type: GET_REPOSITORY.PENDING });
+
+    return v3
+      .get(url, accessToken)
+      .then(response => {
+        return response
+          .json()
+          .then(
+            json => (response.status === 200 ? json : Promise.reject(json))
+          );
+      })
+      .then(data => {
+        dispatch({
+          type: GET_REPOSITORY.SUCCESS,
+          payload: data,
+        });
+      })
+      .catch(error => {
+        dispatch({
+          type: GET_REPOSITORY.ERROR,
+          payload: error,
+        });
+      });
+  };
+};
+
+export const getContributors = url => {
+  return (dispatch, getState) => {
+    const accessToken = getState().auth.accessToken;
+
+    dispatch({ type: GET_REPOSITORY_CONTRIBUTORS.PENDING });
+
+    v3
+      .getJson(url, accessToken)
+      .then(data => {
+        dispatch({
+          type: GET_REPOSITORY_CONTRIBUTORS.SUCCESS,
+          payload: data,
+        });
+      })
+      .catch(error => {
+        dispatch({
+          type: GET_REPOSITORY_CONTRIBUTORS.ERROR,
+          payload: error,
+        });
+      });
+  };
+};
 
 export const getContents = (url, level) => {
   return (dispatch, getState) => {

--- a/src/repository/repository.reducer.js
+++ b/src/repository/repository.reducer.js
@@ -1,4 +1,6 @@
 import {
+  GET_REPOSITORY,
+  GET_REPOSITORY_CONTRIBUTORS,
   GET_REPOSITORY_CONTENTS,
   GET_REPOSITORY_FILE,
   GET_REPOSITORY_README,
@@ -10,6 +12,8 @@ import {
 } from './repository.type';
 
 const initialState = {
+  repository: {},
+  contributors: [],
   labels: [],
   contents: {},
   fileContent: '',
@@ -21,6 +25,8 @@ const initialState = {
   searchedClosedIssues: [],
   searchedOpenPulls: [],
   searchedClosedPulls: [],
+  isPendingRepository: false,
+  isPendingContributors: false,
   isPendingContents: false,
   isPendingFile: false,
   isPendingReadMe: false,
@@ -34,6 +40,49 @@ const initialState = {
 
 export const repositoryReducer = (state = initialState, action = {}) => {
   switch (action.type) {
+    case GET_REPOSITORY.PENDING:
+      return {
+        ...state,
+        contributors: [],
+        issues: [],
+        readMe: '',
+        hasRepoExist: false,
+        hasReadMe: false,
+        error: '',
+        topics: [],
+        isPendingRepository: true,
+      };
+    case GET_REPOSITORY.SUCCESS:
+      return {
+        ...state,
+        repository: action.payload,
+        hasRepoExist: true,
+        error: '',
+        isPendingRepository: false,
+      };
+    case GET_REPOSITORY.ERROR:
+      return {
+        ...initialState,
+        error: action.payload,
+      };
+    case GET_REPOSITORY_CONTRIBUTORS.PENDING:
+      return {
+        ...state,
+        isPendingContributors: true,
+      };
+    case GET_REPOSITORY_CONTRIBUTORS.SUCCESS:
+      return {
+        ...state,
+        contributors: action.payload,
+        isPendingContributors: false,
+      };
+    case GET_REPOSITORY_CONTRIBUTORS.ERROR:
+      return {
+        ...state,
+        error: action.payload,
+        isPendingContributors: false,
+        contributors: [],
+      };
     case GET_REPOSITORY_CONTENTS.PENDING:
       return {
         ...state,

--- a/src/repository/repository.reducer.js
+++ b/src/repository/repository.reducer.js
@@ -1,8 +1,6 @@
 import {
   GET_REPOSITORY_CONTENTS,
   GET_REPOSITORY_FILE,
-  FORK_REPO_STATUS,
-  CHANGE_STAR_STATUS,
   GET_REPOSITORY_README,
   GET_REPOSITORY_LABELS,
   SEARCH_OPEN_ISSUES,
@@ -25,15 +23,12 @@ const initialState = {
   searchedClosedPulls: [],
   isPendingContents: false,
   isPendingFile: false,
-  isPendingChangeStarred: false,
   isPendingReadMe: false,
   isPendingLabels: false,
   isPendingSearchOpenIssues: false,
   isPendingSearchClosedIssues: false,
   isPendingSearchOpenPulls: false,
   isPendingSearchClosedPulls: false,
-  isPendingFork: false,
-  isPendingSubscribe: false,
   error: '',
 };
 
@@ -75,46 +70,6 @@ export const repositoryReducer = (state = initialState, action = {}) => {
         ...state,
         error: action.payload,
         isPendingFile: false,
-      };
-    case FORK_REPO_STATUS.PENDING:
-      return {
-        ...state,
-        isPendingFork: true,
-      };
-    case FORK_REPO_STATUS.SUCCESS:
-      return {
-        ...state,
-        forked: action.payload,
-        isPendingFork: false,
-      };
-    case FORK_REPO_STATUS.ERROR:
-      return {
-        ...state,
-        isPendingFork: false,
-      };
-
-    case CHANGE_STAR_STATUS.PENDING:
-      return {
-        ...state,
-        isPendingChangeStarred: true,
-      };
-    case CHANGE_STAR_STATUS.SUCCESS:
-      return {
-        ...state,
-        starred: action.payload,
-        repository: {
-          ...state.repository,
-          stargazers_count: action.payload
-            ? state.repository.stargazers_count + 1
-            : state.repository.stargazers_count - 1,
-        },
-        isPendingChangeStarred: false,
-      };
-    case CHANGE_STAR_STATUS.ERROR:
-      return {
-        ...state,
-        error: action.payload,
-        isPendingChangeStarred: false,
       };
     case GET_REPOSITORY_README.PENDING:
       return {

--- a/src/repository/repository.reducer.js
+++ b/src/repository/repository.reducer.js
@@ -1,12 +1,6 @@
 import {
-  GET_REPOSITORY,
-  GET_REPOSITORY_CONTRIBUTORS,
   GET_REPOSITORY_CONTENTS,
   GET_REPOSITORY_FILE,
-  GET_REPOSITORY_ISSUES,
-  GET_REPO_README_STATUS,
-  GET_REPO_STARRED_STATUS,
-  GET_REPOSITORY_TOPICS,
   FORK_REPO_STATUS,
   CHANGE_STAR_STATUS,
   GET_REPOSITORY_README,
@@ -15,35 +9,23 @@ import {
   SEARCH_CLOSED_ISSUES,
   SEARCH_OPEN_PULLS,
   SEARCH_CLOSED_PULLS,
-  GET_REPOSITORY_SUBSCRIBED_STATUS,
 } from './repository.type';
 
 const initialState = {
-  repository: {},
-  contributors: [],
   labels: [],
   contents: {},
   fileContent: '',
-  issues: [],
   readMe: '',
   hasRepoExist: false,
-  hasReadMe: false,
-  starred: false,
   forked: false,
   subscribed: false,
   searchedOpenIssues: [],
   searchedClosedIssues: [],
   searchedOpenPulls: [],
   searchedClosedPulls: [],
-  isPendingRepository: false,
-  isPendingContributors: false,
   isPendingContents: false,
   isPendingFile: false,
-  isPendingIssues: false,
-  isPendingCheckReadMe: false,
-  isPendingCheckStarred: false,
   isPendingChangeStarred: false,
-  isPendingCheckSubscribed: false,
   isPendingReadMe: false,
   isPendingLabels: false,
   isPendingSearchOpenIssues: false,
@@ -51,57 +33,12 @@ const initialState = {
   isPendingSearchOpenPulls: false,
   isPendingSearchClosedPulls: false,
   isPendingFork: false,
-  isPendingTopics: false,
   isPendingSubscribe: false,
   error: '',
-  topics: [],
 };
 
 export const repositoryReducer = (state = initialState, action = {}) => {
   switch (action.type) {
-    case GET_REPOSITORY.PENDING:
-      return {
-        ...state,
-        contributors: [],
-        issues: [],
-        readMe: '',
-        hasRepoExist: false,
-        hasReadMe: false,
-        error: '',
-        topics: [],
-        isPendingRepository: true,
-      };
-    case GET_REPOSITORY.SUCCESS:
-      return {
-        ...state,
-        repository: action.payload,
-        hasRepoExist: true,
-        error: '',
-        isPendingRepository: false,
-      };
-    case GET_REPOSITORY.ERROR:
-      return {
-        ...initialState,
-        error: action.payload,
-      };
-    case GET_REPOSITORY_CONTRIBUTORS.PENDING:
-      return {
-        ...state,
-        isPendingContributors: true,
-      };
-    case GET_REPOSITORY_CONTRIBUTORS.SUCCESS:
-      return {
-        ...state,
-        contributors: action.payload,
-        isPendingContributors: false,
-      };
-    case GET_REPOSITORY_CONTRIBUTORS.ERROR:
-      return {
-        ...state,
-        error: action.payload,
-        isPendingContributors: false,
-        contributors: [],
-      };
     case GET_REPOSITORY_CONTENTS.PENDING:
       return {
         ...state,
@@ -139,57 +76,6 @@ export const repositoryReducer = (state = initialState, action = {}) => {
         error: action.payload,
         isPendingFile: false,
       };
-    case GET_REPOSITORY_ISSUES.PENDING:
-      return {
-        ...state,
-        isPendingIssues: true,
-      };
-    case GET_REPOSITORY_ISSUES.SUCCESS:
-      return {
-        ...state,
-        issues: action.payload,
-        isPendingIssues: false,
-      };
-    case GET_REPOSITORY_ISSUES.ERROR:
-      return {
-        ...state,
-        error: action.payload,
-        isPendingIssues: false,
-      };
-    case GET_REPO_README_STATUS.PENDING:
-      return {
-        ...state,
-        isPendingCheckReadMe: true,
-      };
-    case GET_REPO_README_STATUS.SUCCESS:
-      return {
-        ...state,
-        hasReadMe: action.payload,
-        isPendingCheckReadMe: false,
-      };
-    case GET_REPO_README_STATUS.ERROR:
-      return {
-        ...state,
-        error: action.payload,
-        isPendingCheckReadMe: false,
-      };
-    case GET_REPO_STARRED_STATUS.PENDING:
-      return {
-        ...state,
-        isPendingCheckStarred: true,
-      };
-    case GET_REPO_STARRED_STATUS.SUCCESS:
-      return {
-        ...state,
-        starred: action.payload,
-        isPendingCheckStarred: false,
-      };
-    case GET_REPO_STARRED_STATUS.ERROR:
-      return {
-        ...state,
-        error: action.payload,
-        isPendingCheckStarred: false,
-      };
     case FORK_REPO_STATUS.PENDING:
       return {
         ...state,
@@ -206,25 +92,7 @@ export const repositoryReducer = (state = initialState, action = {}) => {
         ...state,
         isPendingFork: false,
       };
-    case GET_REPOSITORY_SUBSCRIBED_STATUS.PENDING:
-      return {
-        ...state,
-        subscribed: false,
-        isPendingSubscribe: true,
-      };
-    case GET_REPOSITORY_SUBSCRIBED_STATUS.SUCCESS:
-      return {
-        ...state,
-        subscribed: action.payload,
-        isPendingSubscribe: false,
-      };
-    case GET_REPOSITORY_SUBSCRIBED_STATUS.ERROR:
-      return {
-        ...state,
-        subscribed: action.payload,
-        isPendingCheckSubscribed: false,
-        isPendingSubscribe: false,
-      };
+
     case CHANGE_STAR_STATUS.PENDING:
       return {
         ...state,
@@ -282,22 +150,7 @@ export const repositoryReducer = (state = initialState, action = {}) => {
         error: action.payload,
         isPendingLabels: false,
       };
-    case GET_REPOSITORY_TOPICS.SUCCESS:
-      return {
-        ...state,
-        topics: action.payload,
-        isPendingTopics: false,
-      };
-    case GET_REPOSITORY_TOPICS.PENDING:
-      return {
-        ...state,
-        isPendingTopics: true,
-      };
-    case GET_REPOSITORY_TOPICS.ERROR:
-      return {
-        ...state,
-        error: action.payload,
-      };
+
     case SEARCH_OPEN_ISSUES.PENDING:
       return {
         ...state,

--- a/src/repository/repository.type.js
+++ b/src/repository/repository.type.js
@@ -4,14 +4,9 @@ export const GET_REPOSITORY_CONTENTS = createActionSet(
   'GET_REPOSITORY_CONTENTS'
 );
 export const GET_REPOSITORY_FILE = createActionSet('GET_REPOSITORY_FILE');
-export const FORK_REPO_STATUS = createActionSet('FORK_REPO_STATUS');
-export const CHANGE_STAR_STATUS = createActionSet('CHANGE_STAR_STATUS');
 export const GET_REPOSITORY_README = createActionSet('GET_REPOSITORY_README');
 export const GET_REPOSITORY_LABELS = createActionSet('GET_REPOSITORY_LABELS');
 export const SEARCH_OPEN_ISSUES = createActionSet('SEARCH_OPEN_ISSUES');
 export const SEARCH_CLOSED_ISSUES = createActionSet('SEARCH_CLOSED_ISSUES');
 export const SEARCH_OPEN_PULLS = createActionSet('SEARCH_OPEN_PULLS');
 export const SEARCH_CLOSED_PULLS = createActionSet('SEARCH_CLOSED_PULLS');
-export const GET_REPOSITORY_SUBSCRIBED_STATUS = createActionSet(
-  'GET_REPOSITORY_SUBSCRIBED_STATUS'
-);

--- a/src/repository/repository.type.js
+++ b/src/repository/repository.type.js
@@ -1,19 +1,9 @@
 import { createActionSet } from 'utils';
 
-export const GET_REPOSITORY = createActionSet('GET_REPOSITORY');
-export const GET_REPOSITORY_CONTRIBUTORS = createActionSet(
-  'GET_REPOSITORY_CONTRIBUTORS'
-);
 export const GET_REPOSITORY_CONTENTS = createActionSet(
   'GET_REPOSITORY_CONTENTS'
 );
 export const GET_REPOSITORY_FILE = createActionSet('GET_REPOSITORY_FILE');
-export const GET_REPOSITORY_ISSUES = createActionSet('GET_REPOSITORY_ISSUES');
-export const GET_REPO_README_STATUS = createActionSet('GET_REPO_README_STATUS');
-export const GET_REPO_STARRED_STATUS = createActionSet(
-  'GET_REPO_STARRED_STATUS'
-);
-export const GET_REPOSITORY_TOPICS = createActionSet('GET_REPOSITORY_TOPICS');
 export const FORK_REPO_STATUS = createActionSet('FORK_REPO_STATUS');
 export const CHANGE_STAR_STATUS = createActionSet('CHANGE_STAR_STATUS');
 export const GET_REPOSITORY_README = createActionSet('GET_REPOSITORY_README');

--- a/src/repository/repository.type.js
+++ b/src/repository/repository.type.js
@@ -1,5 +1,9 @@
 import { createActionSet } from 'utils';
 
+export const GET_REPOSITORY = createActionSet('GET_REPOSITORY');
+export const GET_REPOSITORY_CONTRIBUTORS = createActionSet(
+  'GET_REPOSITORY_CONTRIBUTORS'
+);
 export const GET_REPOSITORY_CONTENTS = createActionSet(
   'GET_REPOSITORY_CONTENTS'
 );

--- a/src/repository/screens/repository-code-list.screen.js
+++ b/src/repository/screens/repository-code-list.screen.js
@@ -9,7 +9,6 @@ import { colors, fonts, normalize } from 'config';
 import { getContents } from '../repository.action';
 
 const mapStateToProps = state => ({
-  repository: state.repository.repository,
   contents: state.repository.contents,
   isPendingContents: state.repository.isPendingContents,
 });
@@ -49,7 +48,6 @@ const styles = StyleSheet.create({
 class RepositoryCodeList extends Component {
   props: {
     getContents: Function,
-    repository: Object,
     contents: Array,
     isPendingContents: boolean,
     navigation: Object,
@@ -58,7 +56,7 @@ class RepositoryCodeList extends Component {
   componentDidMount() {
     const navigationParams = this.props.navigation.state.params;
     const url = navigationParams.topLevel
-      ? this.props.repository.contents_url.replace('{+path}', '')
+      ? navigationParams.contentsUrl
       : navigationParams.content.url;
     const level = navigationParams.topLevel
       ? 'top'

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -7,3 +7,4 @@ export * from './color-helpers';
 export * from './device-helpers';
 export * from './event-helpers';
 export * from './localization-helper';
+export * from './migration-helper';

--- a/src/utils/migration-helper.js
+++ b/src/utils/migration-helper.js
@@ -5,7 +5,7 @@ export const toOldUserFormat = user => {
   };
 };
 
-export const toOldIssueFormat = (issue, repoId) => {
+export const toOldIssueFormat = (issue, repoId, isPr = false) => {
   return {
     ...issue,
     user: toOldUserFormat(issue.author),
@@ -13,6 +13,7 @@ export const toOldIssueFormat = (issue, repoId) => {
     created_at: issue.createdAt,
     closed_at: issue.closedAt,
     state: issue.state.toLowerCase(),
+    pull_request: isPr ? {} : null,
     url: `https://api.github.com/repos/${repoId}/issues/${issue.number}`,
   };
 };

--- a/src/utils/migration-helper.js
+++ b/src/utils/migration-helper.js
@@ -1,0 +1,18 @@
+export const toOldUserFormat = user => {
+  return {
+    ...user,
+    avatar_url: user.avatarUrl,
+  };
+};
+
+export const toOldIssueFormat = (issue, repoId) => {
+  return {
+    ...issue,
+    user: toOldUserFormat(issue.author),
+    comments: issue.comments.totalCount,
+    created_at: issue.createdAt,
+    closed_at: issue.closedAt,
+    state: issue.state.toLowerCase(),
+    url: `https://api.github.com/repos/${repoId}/issues/${issue.number}`,
+  };
+};


### PR DESCRIPTION
| Question         | Response    |
| ---------------- | ----------- |
| Version?         | v1.4.1      |
| Devices tested?  | iPhone 7 |
| Bug fix?         | no      |
| New feature?     | yes      |
| Includes tests?  | no      |
| All Tests pass?  | no      |
| Related ticket?  | #761         |

---

## Description

Introducing GraphQL in the new Redux API 🎉 

Rewrote the repo screen to be loaded with only two requests:
* A GraphQL query to load all the displayed information on the screen
* A REST list query to load the contributors (not provided by GitHub v4 yet)

I also ported star/unstar watch/unwatch & fork to the new API.

For now, the GraphQL query also returns 50 issues & 50 pull requests, to avoid making any changes to the issues/pulls list screens. We will get rid of that once these two screens are rewritten to the new API.

Even with that little performance annoyance, the new screen is blazing fast!

## UX changes

* Starring/Unstarring or Watching/Unwatching are immediately reflected on the UI :

| watching | unwatching | not watching  |
| -- | -- | -- |
|![simulator screen shot - iphone 7 - 2018-04-17 at 02 58 52](https://user-images.githubusercontent.com/304450/38844428-522c45c0-41eb-11e8-8261-cf3ea0684341.png)|![simulator screen shot - iphone 7 - 2018-04-17 at 02 58 56](https://user-images.githubusercontent.com/304450/38844429-524da9a4-41eb-11e8-84ea-1f41a236dfeb.png)|![simulator screen shot - iphone 7 - 2018-04-17 at 02 58 58](https://user-images.githubusercontent.com/304450/38844430-52709d6a-41eb-11e8-8152-c8c7a5b75bd2.png)|

This is possible with the new Client.delete() and Client.put() methods, that allow us to patch the entity in our Store. This logic already showcased for REST in #770, is also compatible with GraphQL.

* Error Page (to be discussed)

When a repository doesn't exist, we currently display a Toast with an error message, and an incomplete Repository screen.

I wanted to simplify things, a create a nicer user experience, so I tweaked this part a bit.

My first approach was to immediately navigate back & display the toast, but the toast length was really limited.

So for now I'm displaying this error page:

|  |
|  -- |
|![simulator screen shot - iphone 7 - 2018-04-17 at 02 48 29](https://user-images.githubusercontent.com/304450/38844579-02097404-41ec-11e8-981f-73629062f28a.png)|

Come to think about it, we already have an ErrorPage component, but with a hardcoded message for now. We could definitely refactor it a bit:
- Allow for a custom message to be passed as a prop
- Give it some UI ❤️ 
- Allow the user to provide us some feedback about how he got to the error (if it's a GitPoint app error) and have that feedback posted as a new issue in the GitPoint repository ✨ 

And icing on the cake, we would use that from the new `componentDidCatch` React lifecycle method and spread that in all our screens.

Any opinions on that ? If accepted, this would have to be done in a separate PR.

NB: For now the new API displays an additional (ugly) alert message meant for debugging.

<!-- DO NOT MODIFY BELOW THIS LINE -->
<!-- ----------------------------- -->
<!-- GITPOINT_PR -->
