### PR TITLE
refactor: switch LoadingContainer to styled components

### DIFF
--- a/src/components/loading-indicators/loading-container.component.js
+++ b/src/components/loading-indicators/loading-container.component.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { StyleSheet, View, ActivityIndicator, Text } from 'react-native';
+import { ActivityIndicator } from 'react-native';
+import styled from 'styled-components';
 
 import { colors, fonts } from 'config';
 
@@ -9,24 +10,21 @@ type Props = {
   center: boolean,
 };
 
-const styles = StyleSheet.create({
-  loadingContainer: {
-    backgroundColor: colors.white,
-    flex: 1,
-    alignItems: 'center',
-  },
-  center: {
-    justifyContent: 'center',
-  },
-  text: {
-    paddingTop: 20,
-    ...fonts.fontPrimary,
-  },
-});
+const Container = styled.View`
+  background-color: ${colors.white};
+  flex: 1;
+  align-items: center;
+  justify-content: ${props => (props.center ? 'center' : 'initial')};
+`;
+
+const Message = styled.Text`
+  padding-top: 20;
+  ${fonts.fontPrimary};
+`;
 
 export const LoadingContainer = ({ animating, text, center }: Props) => (
-  <View style={[styles.loadingContainer, center && styles.center]}>
+  <Container center={center}>
     <ActivityIndicator animating={animating} size="large" />
-    {text && <Text style={styles.text}>{text}</Text>}
-  </View>
+    {text && <Message>{text}</Message>}
+  </Container>
 );


### PR DESCRIPTION

| Question         | Response    |
| ---------------- | ----------- |
| Version?         | v1.4.1      |
| Devices tested?  | iPhone 7 |
| Bug fix?         | no      |
| New feature?     | no      |
| Includes tests?  | no      |
| All Tests pass?  | yes      |
| Related ticket?  | #532        |

---

## Screenshots


| Before   | After    |
| -------- | -------- |
|![simulator screen shot - iphone 6s - 2018-04-23 at 18 43 58](https://user-images.githubusercontent.com/304450/39149842-5d019296-4738-11e8-9c10-b8c203dce340.png)|![simulator screen shot - iphone 6s - 2018-04-23 at 18 46 18](https://user-images.githubusercontent.com/304450/39149848-6015c704-4738-11e8-8828-c5c0dcfc0e74.png)|

## Description

Migrated `LoadingContainer` to styled components


<!-- DO NOT MODIFY BELOW THIS LINE -->
<!-- ----------------------------- -->
<!-- GITPOINT_PR -->
