### PR TITLE
fix: pass props into super() in constructor function

### DIFF
--- a/src/components/comment-input.component.js
+++ b/src/components/comment-input.component.js
@@ -60,8 +60,8 @@ export class CommentInput extends Component {
     height: number,
   };
 
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
 
     this.state = {
       text: '',

--- a/src/components/image-zoom.component.js
+++ b/src/components/image-zoom.component.js
@@ -49,8 +49,8 @@ export class ImageZoom extends Component {
     style: Object,
   };
 
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     this.state = {
       imgZoom: false,
       imgFailed: false,

--- a/src/components/loading-indicators/loading-members-list.component.js
+++ b/src/components/loading-indicators/loading-members-list.component.js
@@ -32,8 +32,8 @@ export class LoadingMembersList extends Component {
     title: string,
   };
 
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     this.state = {
       fadeAnimValue: new Animated.Value(0),
     };

--- a/src/components/loading-indicators/loading-repository-list-item.component.js
+++ b/src/components/loading-indicators/loading-repository-list-item.component.js
@@ -39,8 +39,8 @@ const styles = StyleSheet.create({
 });
 
 export class LoadingRepositoryListItem extends Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     this.state = {
       fadeAnimValue: new Animated.Value(0),
     };

--- a/src/components/loading-indicators/loading-repository-profile.component.js
+++ b/src/components/loading-indicators/loading-repository-profile.component.js
@@ -66,8 +66,8 @@ export class LoadingRepositoryProfile extends Component {
     fadeAnimValue: Animated,
   };
 
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     this.state = {
       fadeAnimValue: new Animated.Value(0),
     };

--- a/src/components/mention-area.component.js
+++ b/src/components/mention-area.component.js
@@ -39,8 +39,8 @@ export class MentionArea extends Component {
     tracking: boolean,
   };
 
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
 
     this.state = {
       height: new Animated.Value(0),

--- a/src/components/parallax-scroll.component.js
+++ b/src/components/parallax-scroll.component.js
@@ -62,8 +62,8 @@ export class ParallaxScroll extends Component {
 
   state: State;
 
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
     this.state = {
       parallaxHeaderHeight: this.getParallaxHeaderHeight(),
     };

--- a/src/components/toggle-view.component.js
+++ b/src/components/toggle-view.component.js
@@ -12,8 +12,8 @@ export class ToggleView extends Component {
     collapsed: boolean,
   };
 
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
 
     this.state = {
       collapsed: true,

--- a/src/issue/screens/new-issue.screen.js
+++ b/src/issue/screens/new-issue.screen.js
@@ -60,8 +60,8 @@ class NewIssue extends Component {
     issueComment: string,
   };
 
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
 
     this.state = {
       issueTitle: '',

--- a/src/issue/screens/pull-merge.screen.js
+++ b/src/issue/screens/pull-merge.screen.js
@@ -74,8 +74,8 @@ class PullMerge extends Component {
     commitMessage: string,
   };
 
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
 
     this.state = {
       mergeMethod: 0,

--- a/src/notifications/screens/notifications.screen.js
+++ b/src/notifications/screens/notifications.screen.js
@@ -162,8 +162,8 @@ class Notifications extends Component {
     navigation: Object,
   };
 
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
 
     this.state = {
       type: NotificationsType.UNREAD,

--- a/src/repository/screens/issue-list.screen.js
+++ b/src/repository/screens/issue-list.screen.js
@@ -136,8 +136,8 @@ class IssueList extends Component {
     searchFocus: boolean,
   };
 
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
 
     this.state = {
       query: '',

--- a/src/repository/screens/pull-list.screen.js
+++ b/src/repository/screens/pull-list.screen.js
@@ -114,8 +114,8 @@ class PullList extends Component {
     searchFocus: boolean,
   };
 
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
 
     this.state = {
       query: '',

--- a/src/repository/screens/repository-file.screen.js
+++ b/src/repository/screens/repository-file.screen.js
@@ -98,8 +98,8 @@ class RepositoryFile extends Component {
     navigation: Object,
   };
 
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
 
     this.state = {
       imageWidth: null,

--- a/src/search/screens/search.screen.js
+++ b/src/search/screens/search.screen.js
@@ -139,8 +139,8 @@ class Search extends Component {
     searchFocus: boolean,
   };
 
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
 
     this.state = {
       query: '',

--- a/src/user/screens/repository-list.screen.js
+++ b/src/user/screens/repository-list.screen.js
@@ -70,8 +70,8 @@ class RepositoryList extends Component {
     searchFocus: boolean,
   };
 
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
 
     this.state = {
       query: '',

--- a/src/utils/loading-animation.js
+++ b/src/utils/loading-animation.js
@@ -23,8 +23,8 @@ export const loadingAnimation = state => {
 
 export const withFadeAnimation = WrappedComponent => {
   return class extends React.Component {
-    constructor() {
-      super();
+    constructor(props) {
+      super(props);
       this.fadeFrom = 0.3;
       this.fadeTo = 0.6;
       this.state = {


### PR DESCRIPTION
<!--
  Bonjour!

  We can't express how grateful we are that you're working on making GitPoint
  better! We're thrilled to take a look at the changes you've made and merge
  them in as soon as possible. Please fill out this template to make the
  reviewal process as quick and smooth as possible. In addition, please make
  sure you remember to add yourself to the contributors list with the following
  command:

  $ yarn contributors:add

  Make sure the title of your PR follows our commit style guidelines (see other
  open PR's for reference if you're confused):

  https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines

  Thanks again for your hard work!
-->

| Question         | Response    |
| ---------------- | ----------- |
| Version?         | v1.4.1      |
| Devices tested?  | iPhone 7... |
| Bug fix?         | yes      |
| New feature?     | no      |
| Includes tests?  | no      |
| All Tests pass?  | yes      |
| Related ticket?  | #...        |

---

## Description

As in [67a17a](https://github.com/gitpoint/git-point/commit/67a17aedec6195f36997cb24431ae2a72f10a01b), the react components doesn't pass props to super call, which results in TypeError if we need to use props in constructor.

From official [react document](https://reactjs.org/docs/state-and-lifecycle.html#adding-local-state-to-a-class): `Class components should always call the base constructor with props`.  This PR enforces all class components in project to follow this guideline, to avoid potential future bugs.

<!--
  What changes did you make?
-->


<!-- DO NOT MODIFY BELOW THIS LINE -->
<!-- ----------------------------- -->
<!-- GITPOINT_PR -->
